### PR TITLE
update RTA reorganiser with correct paths

### DIFF
--- a/lstmcpipe/hiperta/reorganize_dl1hiperta300_to_dl1lstchain060.py
+++ b/lstmcpipe/hiperta/reorganize_dl1hiperta300_to_dl1lstchain060.py
@@ -242,7 +242,7 @@ def create_hfile_out(input_filename, outfile_name, sim_pointer08, config_pointer
                                      dl1_event_node06,
                                      subarray_pointer
                                      )
-    if 'images' in dl1_event_node06.telescope:
+    if 'image' in dl1_event_node06.telescope:
         stack_and_write_images_table(input_filename,
                                      hfile_out,
                                      dl1_event_node06


### PR DESCRIPTION
Again mix with  `image` and `images` key for the ctapipe and lstchain data models....

ctapipe: `/dl1/event/telescope/images/tel_001` [doc](https://github.com/cta-observatory/cta-lstchain/blob/deabb5c3de058954028ead129d2368d2b70404ed/lstchain/io/io.py#L58)
lstchain: `/dl1/event/telescope/image/LST_LSTCam` [doc](https://github.com/cta-observatory/cta-lstchain/blob/deabb5c3de058954028ead129d2368d2b70404ed/lstchain/io/io.py#L58)


