### PR TITLE
Update rtapipe

### DIFF
--- a/lstmcpipe/scripts/script_batch_filelist_rta.py
+++ b/lstmcpipe/scripts/script_batch_filelist_rta.py
@@ -64,13 +64,13 @@ def main():
 
             cmd = [
                 "lstmcpipe_hiperta_r0_to_dl1lstchain",
-                f"-i {file}",
-                f"-o {args.output_dir}",
-                f"-k {args.keep_file}",
-                f"-d {args.debug_mode}",
+                f"--infile={file}",
+                f"--outdir={args.output_dir}",
+                f"--keep_file={args.keep_file}",
+                f"--debug_mode={args.debug_mode}",
             ]
             if args.config_file:
-                cmd.append("--config={}".format(args.config_file))
+                cmd.append(f"--config={args.config_file}")
 
             subprocess.run(cmd)
 

--- a/lstmcpipe/stages/mc_merge_and_copy_dl1.py
+++ b/lstmcpipe/stages/mc_merge_and_copy_dl1.py
@@ -331,18 +331,15 @@ def merge_dl1(
         cmd += (
             f" -J {job_name[particle]} -e slurm-{job_name[particle]}-{set_type}.o "
             f'-o slurm-{job_name[particle]}-{set_type}.e --wrap="{source_environment} '
-            f'lstchain_merge_hdf5_files -d {tdir} -o {output_filename} --no-image {flag_no_image}'
         )
 
+        # Close " of wrap
         if workflow_kind == "lstchain":
-            cmd += '"'  # Close " of wrap
+            cmd += f'lstchain_merge_hdf5_files -d {tdir} -o {output_filename} --no-image {flag_no_image}"'
         elif workflow_kind == "hiperta":
-            cmd += f'--smart {flag_merge}"'  # HiPeRTA workflow still uses --smart flag
-        else:
-            cmd += (
-                f" -J {job_name[particle]} -e slurm-{job_name[particle]}-{set_type}.o "
-                f'-o slurm-{job_name[particle]}-{set_type}.e --wrap="{source_environment} '
-            )
+            cmd += f'lstchain_merge_hdf5_files -d {tdir} -o {output_filename} --no-image {flag_no_image} ' \
+                   f'--smart {flag_merge}"'  # HiPeRTA workflow still uses --smart flag
+        else:  # ctapipe case
             if flag_no_image:
                 cmd += f'ctapipe-merge --input-dir {tdir} --output {output_filename} --skip-images --skip-simu-images"'
             else:

--- a/lstmcpipe/stages/mc_r0_to_dl1.py
+++ b/lstmcpipe/stages/mc_r0_to_dl1.py
@@ -207,7 +207,8 @@ def r0_to_dl1(
         jobtype_id = "CTA"
     elif workflow_kind == "hiperta":
         base_cmd = (
-            f"{source_environment} lstmcpipe_rta_core_r0_dl1 -k {keep_rta_file} -d False "
+            f"{source_environment} lstmcpipe_rta_core_r0_dl1 -k {keep_rta_file} "
+            f"--debug_mode False -c {config_file}"
         )
         jobtype_id = "RTA"
     else:

--- a/lstmcpipe/stages/mc_r0_to_dl1.py
+++ b/lstmcpipe/stages/mc_r0_to_dl1.py
@@ -143,9 +143,9 @@ def r0_to_dl1(
         Path to a configuration file. If none is given, the standard configuration of the selected pipeline is applied
     train_test_ratio: float
         Ratio of training data. Default = 0.5
-    random_seed : int
+    rng : int
         Random seed for random processes. Default = 42
-    n_r0_files_per_dl1_job : int
+    n_r0_per_dl1_job : int
         Number of r0 files processed by each r0_to_dl1 batched stage. If set to None (Default), see below the `usual
         production` case.n_r0_files_per_dl1_job
 
@@ -206,11 +206,8 @@ def r0_to_dl1(
         base_cmd = f"{source_environment} lstmcpipe_cta_core_r0_dl1 -c {config_file} "
         jobtype_id = "CTA"
     elif workflow_kind == "hiperta":
-        rta_source_env = (
-            "source /home/enrique.garcia/.bashrc; conda activate rta_2night; "
-        )
         base_cmd = (
-            f"{rta_source_env} lstmcpipe_rta_core_r0_dl1 -k {keep_rta_file} -d False "
+            f"{source_environment} lstmcpipe_rta_core_r0_dl1 -k {keep_rta_file} -d False "
         )
         jobtype_id = "RTA"
     else:

--- a/lstmcpipe/stages/mc_r0_to_dl1.py
+++ b/lstmcpipe/stages/mc_r0_to_dl1.py
@@ -207,7 +207,7 @@ def r0_to_dl1(
         jobtype_id = "CTA"
     elif workflow_kind == "hiperta":
         rta_source_env = (
-            "source /home/enrique.garcia/.bashrc; conda activate rta_2night"
+            "source /home/enrique.garcia/.bashrc; conda activate rta_2night; "
         )
         base_cmd = (
             f"{rta_source_env} lstmcpipe_rta_core_r0_dl1 -k {keep_rta_file} -d False "

--- a/lstmcpipe/stages/mc_r0_to_dl1.py
+++ b/lstmcpipe/stages/mc_r0_to_dl1.py
@@ -207,8 +207,8 @@ def r0_to_dl1(
         jobtype_id = "CTA"
     elif workflow_kind == "hiperta":
         base_cmd = (
-            f"{source_environment} lstmcpipe_rta_core_r0_dl1 -k {keep_rta_file} "
-            f"--debug_mode False -c {config_file}"
+            f"{source_environment} lstmcpipe_rta_core_r0_dl1 -c {config_file} "
+            f"--debug_mode False -k {keep_rta_file}"
         )
         jobtype_id = "RTA"
     else:

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     version=version,
     description=description,
     install_requires=[
-        "lstchain>=0.6",
+        "lstchain",
         "pyyaml",
         "numpy",
         "astropy",


### PR DESCRIPTION
 -  rta core script not working.
 - parse source env for the hiperta workflow with the config file (was hardcoded before - lstrta user was not existing)
 - bug on the merging stage.
 - improved docstring
 - take out condition on setup for lstchain. It was installing 0.8 despite that 0.6 was installed (HiPeRTA case).