### PR TITLE
Add production for Galactic analysis: z40, south pointing, NSB tuning

### DIFF
--- a/production_configs/20220302_rsoph/lstchain_config_NSBtuningRSOph.json
+++ b/production_configs/20220302_rsoph/lstchain_config_NSBtuningRSOph.json
@@ -1,0 +1,274 @@
+{
+    "source_config" : {
+      "EventSource": {
+        "allowed_tels": [1],
+        "max_events": null
+      },
+      "LSTEventSource": {
+        "default_trigger_type": "ucts",
+        "allowed_tels": [1],
+        "min_flatfield_adc": 3000,
+        "min_flatfield_pixel_fraction": 0.8,
+        "calibrate_flatfields_and_pedestals": false,
+        "EventTimeCalculator": {
+          "dragon_reference_counter": null,
+          "dragon_reference_time": null
+        },
+        "PointingSource":{
+          "drive_report_path": null
+        },
+        "LSTR0Corrections":{
+          "calib_scale_high_gain":1.088,
+          "calib_scale_low_gain":1.004,
+          "drs4_pedestal_path": null,
+          "calibration_path": null,
+          "drs4_time_calibration_path": null
+        }
+      }
+    },
+
+    "events_filters": {
+      "intensity": [0, Infinity],
+      "width": [0, Infinity],
+      "length": [0, Infinity],
+      "wl": [0, Infinity],
+      "r": [0, Infinity],
+      "leakage_intensity_width_2": [0, Infinity]
+    },
+
+    "tailcut": {
+      "picture_thresh":8,
+      "boundary_thresh":4,
+      "keep_isolated_pixels":false,
+      "min_number_picture_neighbors":2,
+      "use_only_main_island":false,
+      "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+      "picture_thresh":6,
+      "boundary_thresh":3,
+      "sigma":2.5,
+      "keep_isolated_pixels":false,
+      "min_number_picture_neighbors":2,
+      "use_only_main_island":false,
+      "delta_time": 2
+    },
+    "dynamic_cleaning": {
+      "apply": true,
+      "threshold": 267,
+      "fraction_cleaning_intensity": 0.03
+    },
+
+    "random_forest_energy_regressor_args": {
+      "max_depth": 50,
+      "min_samples_leaf": 2,
+      "n_jobs": 4,
+      "n_estimators": 150,
+      "bootstrap": true,
+      "criterion": "squared_error",
+      "max_features": "auto",
+      "max_leaf_nodes": null,
+      "min_impurity_decrease": 0.0,
+      "min_samples_split": 2,
+      "min_weight_fraction_leaf": 0.0,
+      "oob_score": false,
+      "random_state": 42,
+      "verbose": 0,
+      "warm_start": false
+    },
+
+    "random_forest_disp_regressor_args": {
+      "max_depth": 50,
+      "min_samples_leaf": 2,
+      "n_jobs": 4,
+      "n_estimators": 150,
+      "bootstrap": true,
+      "criterion": "squared_error",
+      "max_features": "auto",
+      "max_leaf_nodes": null,
+      "min_impurity_decrease": 0.0,
+      "min_samples_split": 2,
+      "min_weight_fraction_leaf": 0.0,
+      "oob_score": false,
+      "random_state": 42,
+      "verbose": 0,
+      "warm_start": false
+    },
+
+    "random_forest_disp_classifier_args": {
+      "max_depth": 100,
+      "min_samples_leaf": 2,
+      "n_jobs": 4,
+      "n_estimators": 100,
+      "criterion": "gini",
+      "min_samples_split": 2,
+      "min_weight_fraction_leaf": 0.0,
+      "max_features": "auto",
+      "max_leaf_nodes": null,
+      "min_impurity_decrease": 0.0,
+      "bootstrap": true,
+      "oob_score": false,
+      "random_state": 42,
+      "verbose": 0.0,
+      "warm_start": false,
+      "class_weight": null
+    },
+
+    "random_forest_particle_classifier_args": {
+      "max_depth": 100,
+      "min_samples_leaf": 2,
+      "n_jobs": 4,
+      "n_estimators": 100,
+      "criterion": "gini",
+      "min_samples_split": 2,
+      "min_weight_fraction_leaf": 0.0,
+      "max_features": "auto",
+      "max_leaf_nodes": null,
+      "min_impurity_decrease": 0.0,
+      "bootstrap": true,
+      "oob_score": false,
+      "random_state": 42,
+      "verbose": 0.0,
+      "warm_start": false,
+      "class_weight": null
+    },
+
+
+    "energy_regression_features": [
+      "log_intensity",
+      "width",
+      "length",
+      "x",
+      "y",
+      "wl",
+      "skewness",
+      "kurtosis",
+      "time_gradient",
+      "leakage_intensity_width_2"
+    ],
+
+    "disp_method": "disp_norm_sign",
+
+    "disp_regression_features": [
+      "log_intensity",
+      "width",
+      "length",
+      "wl",
+      "skewness",
+      "kurtosis",
+      "time_gradient",
+      "leakage_intensity_width_2"
+    ],
+
+    "disp_classification_features": [
+      "log_intensity",
+      "width",
+      "length",
+      "wl",
+      "skewness",
+      "kurtosis",
+      "time_gradient",
+      "leakage_intensity_width_2"
+    ],
+
+    "particle_classification_features": [
+      "log_intensity",
+      "width",
+      "length",
+      "x",
+      "y",
+      "wl",
+      "skewness",
+      "kurtosis",
+      "time_gradient",
+      "leakage_intensity_width_2",
+      "log_reco_energy",
+      "reco_disp_norm",
+      "reco_disp_sign"
+    ],
+
+    "allowed_tels": [1],
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+      "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum":{
+      "window_shift": 4,
+      "window_width": 8,
+      "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum":{
+      "window_shift": 4,
+      "window_width": 8,
+      "apply_integration_correction": false
+    },
+    "timestamps_pointing":"ucts",
+
+    "train_gamma_src_r_deg": [0, Infinity],
+
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+
+    "volume_reducer":{
+      "algorithm": null,
+      "parameters": {
+      }
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+
+    "LSTCalibrationCalculator":{
+      "systematic_correction_path": null,
+      "squared_excess_noise_factor": 1.222,
+      "flatfield_product": "FlasherFlatFieldCalculator",
+      "pedestal_product": "PedestalIntegrator",
+      "PedestalIntegrator":{
+        "sample_size": 10000,
+        "sample_duration":100000,
+        "tel_id":1,
+        "time_sampling_correction_path": null,
+        "charge_median_cut_outliers": [-10,10],
+        "charge_std_cut_outliers": [-10,10],
+        "charge_product":"FixedWindowSum",
+        "FixedWindowSum":{
+          "window_shift": 6,
+          "window_width":12,
+          "peak_index": 18,
+          "apply_integration_correction": false
+        }
+      },
+      "FlasherFlatFieldCalculator":{
+        "sample_size": 10000,
+        "sample_duration":100000,
+        "tel_id":1,
+        "time_sampling_correction_path": null,
+        "charge_product":"LocalPeakWindowSum",
+        "charge_median_cut_outliers": [-0.5,0.5],
+        "charge_std_cut_outliers": [-10,10],
+        "time_cut_outliers": [2,38],
+        "LocalPeakWindowSum":{
+          "window_shift": 5,
+          "window_width":12,
+          "apply_integration_correction": false
+        }
+      }
+    },
+    "waveform_nsb_tuning":{
+      "nsb_tuning": false,
+      "nsb_tuning_ratio": 0.52,
+      "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    },
+    "image_modifier": {
+        "increase_nsb": true,
+        "extra_noise_in_dim_pixels": 0.6,
+        "extra_bias_in_dim_pixels": 0.269,
+        "transition_charge": 8,
+        "extra_noise_in_bright_pixels": 0.566,
+        "increase_psf": true,
+        "smeared_light_fraction": 0.175
+    }
+}

--- a/production_configs/20220302_rsoph/lstmcpipe_config.yml
+++ b/production_configs/20220302_rsoph/lstmcpipe_config.yml
@@ -13,7 +13,7 @@
 
 
 workflow_kind: lstchain  # Not expected to be changed by the user
-#prod_id:                 # ex: local_no_n_islands. Default; v00 (if key left empty or None)
+prod_id: tuned_rsoph                 # ex: local_no_n_islands. Default; v00 (if key left empty or None)
 
 base_path: /fefs/aswg/workspace/MC_data_simlink  # Default user path
   # lstanalyzer user : /fefs/aswg/data/mc

--- a/production_configs/20220302_rsoph/lstmcpipe_config.yml
+++ b/production_configs/20220302_rsoph/lstmcpipe_config.yml
@@ -1,0 +1,58 @@
+## MC PRODUCTION FULL PIPELINE CONFIGURATION ##
+#
+# The entries are needed to correctly select the MC production type
+#  and to create the common path tree;
+#
+#
+#   $BASE_PATH_DL0/$STAGE/$OBS_DATE/$PARTICLE/$ZENITH/$POINTING/$PROD_ID
+#
+#
+#  This way every MC production will follow the same path logic;
+#    ex;  $BASE_PATH_DL0/{DL0, DL1, DL2, running_analysis}/20200629_prod5/{electron, gamma, gamma-diffuse, proton}/
+#          /zenith_20deg/south_pointing/$PROD_ID
+
+
+workflow_kind: lstchain  # Not expected to be changed by the user
+#prod_id:                 # ex: local_no_n_islands. Default; v00 (if key left empty or None)
+
+base_path: /fefs/aswg/workspace/MC_data_simlink  # Default user path
+  # lstanalyzer user : /fefs/aswg/data/mc
+  #
+# Only for dl1 reprocessing
+#dl1_reference_id: #old id including versions (full directory name)
+prod_type: prod5
+  # Choose between {prod5, prod3}
+obs_date: 20200629_prod5_trans_80
+  # prod5 : `20200629_prod5` or `20200629_prod5_trans_80`
+  # pro3 : `20190415`
+zenith: zenith_40deg  # Taken into account only when `prod_type: prod5` [ thus `obs_date` : 20200629_prod5(_trans_80) ]
+pointing: south_pointing
+particles:
+  - electron
+  - gamma
+  - gamma-diffuse
+  - proton
+offset_gammas:  # Taken into account only when `prod_type: prod5` [ thus `obs_date`: 20200629_prod5(_trans_80) ]
+  - off0.0deg
+  - off0.4deg
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.9.3
+  # user example: "source /fefs/home/enrique.garcia/.bashrc; conda activate lst-dev" should be writen:
+  #   source_file: /fefs/home/enrique.garcia/.bashrc
+  #   conda_env: lst-dev
+
+stages_to_be_run:
+  - r0_to_dl1
+  - merge_and_copy_dl1
+  - train_pipe
+  - dl1_to_dl2
+  - dl2_to_irfs
+  - dl2_to_sensitivity
+
+merging_options:
+  no_image: True
+
+slurm_config:
+  user_account: aswg

--- a/production_configs/20220302_rsoph/readme.md
+++ b/production_configs/20220302_rsoph/readme.md
@@ -1,0 +1,11 @@
+# RS Ophiuchi Config
+
+## 20220301_rsoph
+
+## Short description of the config
+
+Config for 40zd and 180deg with tuning to the NSB of the RS Ophiuchi field
+
+## Why this config is needed
+
+Processing of RS Ophiuchi data from August 2021

--- a/production_configs/20220302_tuned_rsoph/lstchain_config_NSBtuningRSOph.json
+++ b/production_configs/20220302_tuned_rsoph/lstchain_config_NSBtuningRSOph.json
@@ -1,0 +1,274 @@
+{
+    "source_config" : {
+      "EventSource": {
+        "allowed_tels": [1],
+        "max_events": null
+      },
+      "LSTEventSource": {
+        "default_trigger_type": "ucts",
+        "allowed_tels": [1],
+        "min_flatfield_adc": 3000,
+        "min_flatfield_pixel_fraction": 0.8,
+        "calibrate_flatfields_and_pedestals": false,
+        "EventTimeCalculator": {
+          "dragon_reference_counter": null,
+          "dragon_reference_time": null
+        },
+        "PointingSource":{
+          "drive_report_path": null
+        },
+        "LSTR0Corrections":{
+          "calib_scale_high_gain":1.088,
+          "calib_scale_low_gain":1.004,
+          "drs4_pedestal_path": null,
+          "calibration_path": null,
+          "drs4_time_calibration_path": null
+        }
+      }
+    },
+
+    "events_filters": {
+      "intensity": [0, Infinity],
+      "width": [0, Infinity],
+      "length": [0, Infinity],
+      "wl": [0, Infinity],
+      "r": [0, Infinity],
+      "leakage_intensity_width_2": [0, Infinity]
+    },
+
+    "tailcut": {
+      "picture_thresh":8,
+      "boundary_thresh":4,
+      "keep_isolated_pixels":false,
+      "min_number_picture_neighbors":2,
+      "use_only_main_island":false,
+      "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+      "picture_thresh":6,
+      "boundary_thresh":3,
+      "sigma":2.5,
+      "keep_isolated_pixels":false,
+      "min_number_picture_neighbors":2,
+      "use_only_main_island":false,
+      "delta_time": 2
+    },
+    "dynamic_cleaning": {
+      "apply": true,
+      "threshold": 267,
+      "fraction_cleaning_intensity": 0.03
+    },
+
+    "random_forest_energy_regressor_args": {
+      "max_depth": 50,
+      "min_samples_leaf": 2,
+      "n_jobs": 4,
+      "n_estimators": 150,
+      "bootstrap": true,
+      "criterion": "squared_error",
+      "max_features": "auto",
+      "max_leaf_nodes": null,
+      "min_impurity_decrease": 0.0,
+      "min_samples_split": 2,
+      "min_weight_fraction_leaf": 0.0,
+      "oob_score": false,
+      "random_state": 42,
+      "verbose": 0,
+      "warm_start": false
+    },
+
+    "random_forest_disp_regressor_args": {
+      "max_depth": 50,
+      "min_samples_leaf": 2,
+      "n_jobs": 4,
+      "n_estimators": 150,
+      "bootstrap": true,
+      "criterion": "squared_error",
+      "max_features": "auto",
+      "max_leaf_nodes": null,
+      "min_impurity_decrease": 0.0,
+      "min_samples_split": 2,
+      "min_weight_fraction_leaf": 0.0,
+      "oob_score": false,
+      "random_state": 42,
+      "verbose": 0,
+      "warm_start": false
+    },
+
+    "random_forest_disp_classifier_args": {
+      "max_depth": 100,
+      "min_samples_leaf": 2,
+      "n_jobs": 4,
+      "n_estimators": 100,
+      "criterion": "gini",
+      "min_samples_split": 2,
+      "min_weight_fraction_leaf": 0.0,
+      "max_features": "auto",
+      "max_leaf_nodes": null,
+      "min_impurity_decrease": 0.0,
+      "bootstrap": true,
+      "oob_score": false,
+      "random_state": 42,
+      "verbose": 0.0,
+      "warm_start": false,
+      "class_weight": null
+    },
+
+    "random_forest_particle_classifier_args": {
+      "max_depth": 100,
+      "min_samples_leaf": 2,
+      "n_jobs": 4,
+      "n_estimators": 100,
+      "criterion": "gini",
+      "min_samples_split": 2,
+      "min_weight_fraction_leaf": 0.0,
+      "max_features": "auto",
+      "max_leaf_nodes": null,
+      "min_impurity_decrease": 0.0,
+      "bootstrap": true,
+      "oob_score": false,
+      "random_state": 42,
+      "verbose": 0.0,
+      "warm_start": false,
+      "class_weight": null
+    },
+
+
+    "energy_regression_features": [
+      "log_intensity",
+      "width",
+      "length",
+      "x",
+      "y",
+      "wl",
+      "skewness",
+      "kurtosis",
+      "time_gradient",
+      "leakage_intensity_width_2"
+    ],
+
+    "disp_method": "disp_norm_sign",
+
+    "disp_regression_features": [
+      "log_intensity",
+      "width",
+      "length",
+      "wl",
+      "skewness",
+      "kurtosis",
+      "time_gradient",
+      "leakage_intensity_width_2"
+    ],
+
+    "disp_classification_features": [
+      "log_intensity",
+      "width",
+      "length",
+      "wl",
+      "skewness",
+      "kurtosis",
+      "time_gradient",
+      "leakage_intensity_width_2"
+    ],
+
+    "particle_classification_features": [
+      "log_intensity",
+      "width",
+      "length",
+      "x",
+      "y",
+      "wl",
+      "skewness",
+      "kurtosis",
+      "time_gradient",
+      "leakage_intensity_width_2",
+      "log_reco_energy",
+      "reco_disp_norm",
+      "reco_disp_sign"
+    ],
+
+    "allowed_tels": [1],
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+      "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum":{
+      "window_shift": 4,
+      "window_width": 8,
+      "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum":{
+      "window_shift": 4,
+      "window_width": 8,
+      "apply_integration_correction": false
+    },
+    "timestamps_pointing":"ucts",
+
+    "train_gamma_src_r_deg": [0, Infinity],
+
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+
+    "volume_reducer":{
+      "algorithm": null,
+      "parameters": {
+      }
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+
+    "LSTCalibrationCalculator":{
+      "systematic_correction_path": null,
+      "squared_excess_noise_factor": 1.222,
+      "flatfield_product": "FlasherFlatFieldCalculator",
+      "pedestal_product": "PedestalIntegrator",
+      "PedestalIntegrator":{
+        "sample_size": 10000,
+        "sample_duration":100000,
+        "tel_id":1,
+        "time_sampling_correction_path": null,
+        "charge_median_cut_outliers": [-10,10],
+        "charge_std_cut_outliers": [-10,10],
+        "charge_product":"FixedWindowSum",
+        "FixedWindowSum":{
+          "window_shift": 6,
+          "window_width":12,
+          "peak_index": 18,
+          "apply_integration_correction": false
+        }
+      },
+      "FlasherFlatFieldCalculator":{
+        "sample_size": 10000,
+        "sample_duration":100000,
+        "tel_id":1,
+        "time_sampling_correction_path": null,
+        "charge_product":"LocalPeakWindowSum",
+        "charge_median_cut_outliers": [-0.5,0.5],
+        "charge_std_cut_outliers": [-10,10],
+        "time_cut_outliers": [2,38],
+        "LocalPeakWindowSum":{
+          "window_shift": 5,
+          "window_width":12,
+          "apply_integration_correction": false
+        }
+      }
+    },
+    "waveform_nsb_tuning":{
+      "nsb_tuning": false,
+      "nsb_tuning_ratio": 0.52,
+      "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    },
+    "image_modifier": {
+        "increase_nsb": true,
+        "extra_noise_in_dim_pixels": 0.6,
+        "extra_bias_in_dim_pixels": 0.269,
+        "transition_charge": 8,
+        "extra_noise_in_bright_pixels": 0.566,
+        "increase_psf": true,
+        "smeared_light_fraction": 0.175
+    }
+}

--- a/production_configs/20220302_tuned_rsoph/lstmcpipe_config.yml
+++ b/production_configs/20220302_tuned_rsoph/lstmcpipe_config.yml
@@ -1,0 +1,58 @@
+## MC PRODUCTION FULL PIPELINE CONFIGURATION ##
+#
+# The entries are needed to correctly select the MC production type
+#  and to create the common path tree;
+#
+#
+#   $BASE_PATH_DL0/$STAGE/$OBS_DATE/$PARTICLE/$ZENITH/$POINTING/$PROD_ID
+#
+#
+#  This way every MC production will follow the same path logic;
+#    ex;  $BASE_PATH_DL0/{DL0, DL1, DL2, running_analysis}/20200629_prod5/{electron, gamma, gamma-diffuse, proton}/
+#          /zenith_20deg/south_pointing/$PROD_ID
+
+
+workflow_kind: lstchain  # Not expected to be changed by the user
+prod_id: tuned_rsoph                 # ex: local_no_n_islands. Default; v00 (if key left empty or None)
+
+base_path: /fefs/aswg/workspace/MC_data_simlink  # Default user path
+  # lstanalyzer user : /fefs/aswg/data/mc
+  #
+# Only for dl1 reprocessing
+#dl1_reference_id: #old id including versions (full directory name)
+prod_type: prod5
+  # Choose between {prod5, prod3}
+obs_date: 20200629_prod5_trans_80
+  # prod5 : `20200629_prod5` or `20200629_prod5_trans_80`
+  # pro3 : `20190415`
+zenith: zenith_40deg  # Taken into account only when `prod_type: prod5` [ thus `obs_date` : 20200629_prod5(_trans_80) ]
+pointing: south_pointing
+particles:
+  - electron
+  - gamma
+  - gamma-diffuse
+  - proton
+offset_gammas:  # Taken into account only when `prod_type: prod5` [ thus `obs_date`: 20200629_prod5(_trans_80) ]
+  - off0.0deg
+  - off0.4deg
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.9.3
+  # user example: "source /fefs/home/enrique.garcia/.bashrc; conda activate lst-dev" should be writen:
+  #   source_file: /fefs/home/enrique.garcia/.bashrc
+  #   conda_env: lst-dev
+
+stages_to_be_run:
+  - r0_to_dl1
+  - merge_and_copy_dl1
+  - train_pipe
+  - dl1_to_dl2
+  - dl2_to_irfs
+  - dl2_to_sensitivity
+
+merging_options:
+  no_image: True
+
+slurm_config:
+  user_account: aswg

--- a/production_configs/20220302_tuned_rsoph/readme.md
+++ b/production_configs/20220302_tuned_rsoph/readme.md
@@ -1,0 +1,11 @@
+# RS Ophiuchi Config
+
+## 20220301_rsoph
+
+## Short description of the config
+
+Config for 40zd and 180deg with tuning to the NSB of the RS Ophiuchi field
+
+## Why this config is needed
+
+Processing of RS Ophiuchi data from August 2021

--- a/production_configs/20220302_tuned_rsoph/readme.md
+++ b/production_configs/20220302_tuned_rsoph/readme.md
@@ -1,6 +1,6 @@
 # RS Ophiuchi Config
 
-## 20220301_rsoph
+## 20220301_tuned_rsoph
 
 ## Short description of the config
 


### PR DESCRIPTION
Request for new production for the analysis of Galactic data with NSB tuning for dark nights, processed with lstchain 0.9.3.


<!---  
You may leave this message, it will be commented out in your PR.
- if you are requesting a new config to be processed, please use the New Prod Config template
- if you are proposing changes to lstmcpipe library delete the template and describe your PR as usual
--->

<!---  
New Prod Config template
Add date and prodid and fill the template
Your Pull Request must include the following files placed in directory `production_configs/yyyymmdd_prod_id`:
- lstmcpipe config file
- lstchain config
- readme.md

Add label `new_prod_config`
---> 


## 20220301_tuned_galactic_field

## Short description of the config

Config for 40zd and 180deg with tuning to the NSB of ta galactic source
