### PR TITLE
create prod_logs directory outside package. 

### DIFF
--- a/lstmcpipe/__init__.py
+++ b/lstmcpipe/__init__.py
@@ -1,1 +1,5 @@
+from pathlib import Path
+
+lstmcpipe_root_dir = Path(__file__).absolute().parents[1]
+
 __version__ = "0.6.1"

--- a/lstmcpipe/io/lstmcpipe_tree_path.py
+++ b/lstmcpipe/io/lstmcpipe_tree_path.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+from pathlib import Path
+from lstmcpipe import lstmcpipe_root_dir, __version__
+
+
+def backup_log(file):
+    """
+    Backups a log file.
+    This scenario should only happens if a MC prod is relaunched because it failed.
+
+    Parameters
+    ----------
+    file : Path
+        Path object to the file to be 'backup-ed'
+    """
+    if file.exists():
+        counter = 0
+        save_file = Path(file.parent, f"BACKUP_{counter:02d}_{file.name}")
+
+        while save_file.exists():
+            counter += 1
+            save_file = Path(file.parent, f"BACKUP_{counter:02d}_{file.name}")
+
+        save_file.mkdir(exist_ok=True)
+
+
+def create_log_dir(prod_id):
+    """
+
+    Parameters
+    ----------
+    prod_id : str
+        production identifier of the MC production to be launched
+
+    Returns
+    -------
+    log_dir : Path
+        Path to `prod_id` log directory
+    """
+    log_dir = lstmcpipe_root_dir.joinpath("prod_logs", f"logs_{prod_id}")
+    log_dir.mkdir(exist_ok=True, parents=True)
+    return log_dir
+
+
+def create_log_files(production_id):
+    """
+    Manages filenames (and overwrites if needed) log files.
+
+    Parameters
+    ----------
+    production_id : str
+        production identifier of the MC production to be launched
+
+    Returns
+    -------
+    logs_files: dict
+        Dictionary containing
+            log_file: Path - path and filename of full log file
+            debug_file: Path - path and filename of reduced (debug) log file
+    scancel_file: Path
+        path and filename of bash file to cancel all the scheduled jobs
+    lstmcpipe_log_dir : Path
+        Path to prod_ID log directory
+    """
+    lstmcpipe_log_dir = create_log_dir(production_id)
+    log_file = lstmcpipe_log_dir.joinpath(f"log_lstmcpipe_v{__version__}_{production_id}.yml")
+    debug_file = lstmcpipe_log_dir.joinpath(f"log_reduced_{production_id}.yml")
+    scancel_file = lstmcpipe_log_dir.joinpath(f"scancel_{production_id}.sh")
+
+    # scancel prod file needs chmod +x rights !
+    if scancel_file.exists():
+        backup_log(scancel_file)
+        scancel_file.unlink()
+    scancel_file.touch()
+    scancel_file.chmod(0o755)  # -rwxr-xr-x
+
+    # If the file exists, i,e., the pipeline has been relaunched, save logs erase it
+    if log_file.exists():
+        backup_log(log_file)
+        log_file.unlink()
+    if debug_file.exists():
+        backup_log(debug_file)
+        debug_file.unlink()
+
+    logs_files = {
+        "log_file": log_file,
+        "debug_file": debug_file
+    }
+
+    return logs_files, scancel_file, lstmcpipe_log_dir
+
+
+def update_scancel_file(scancel_file, jobids_to_update):
+    """
+    Bash file containing the slurm command to cancel multiple jobs.
+    The file will be updated after every batched stage and will be erased in case the whole MC prod succeed without
+    errors.
+
+    Parameters
+    ----------
+    scancel_file: pathlib.Path
+        filename that cancels the whole MC production
+    jobids_to_update: str
+        job_ids to be included into the the file
+    """
+    if scancel_file.stat().st_size == 0:
+        with open(scancel_file, "r+") as f:
+            f.write(f"scancel {jobids_to_update}")
+
+    else:
+        with open(scancel_file, "a") as f:
+            f.write(f",{jobids_to_update}")

--- a/lstmcpipe/io/tests/test_lstmcpipe_tree_path.py
+++ b/lstmcpipe/io/tests/test_lstmcpipe_tree_path.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from lstmcpipe import lstmcpipe_root_dir
+
+
+def test_create_log_files():
+    from ..lstmcpipe_tree_path import create_log_files
+    logs, scancel_file = create_log_files('dummy_prodID')
+
+    assert "log_file" in logs.keys()
+    assert "debug_file" in logs.keys()
+
+    assert isinstance(logs["log_file"], Path)
+    assert isinstance(logs["debug_file"], Path)
+    assert isinstance(scancel_file, Path)
+
+    assert scancel_file.exists()
+
+
+def test_update_scancel_file():
+    from ..lstmcpipe_tree_path import create_log_files, update_scancel_file
+    _, scancel_file = create_log_files("dummy_prodID")
+
+    update_scancel_file(scancel_file, "1234")
+    with open(scancel_file) as f:
+        lines = f.readlines()
+    assert lines == ["scancel 1234"]
+
+    update_scancel_file(scancel_file, "5678")
+    with open(scancel_file) as f:
+        lines = f.readlines()
+    assert lines == ["scancel 1234,5678"]
+
+
+def test_backup_log():
+    from ..lstmcpipe_tree_path import backup_log
+    dummy_file = Path('./test_file.txt')
+    dummy_file.touch()
+
+    saved_file_0 = Path('./BACKUP_00_test_file.txt')
+    saved_file_1 = Path('./BACKUP_01_test_file.txt')
+
+    backup_log(dummy_file)
+    assert saved_file_0.exists()
+    backup_log(dummy_file)
+    assert saved_file_1.exists()
+
+    dummy_file.unlink()
+    saved_file_0.unlink()
+    saved_file_1.unlink()
+
+
+def test_create_log_dir():
+    from ..lstmcpipe_tree_path import create_log_dir
+    dirname = create_log_dir('test_prodID')
+    assert dirname.is_dir()
+    assert dirname.name == lstmcpipe_root_dir.joinpath('prod_logs', 'logs_test_prodID').name
+    dirname.rmdir()

--- a/lstmcpipe/lstmcpipe_start.py
+++ b/lstmcpipe/lstmcpipe_start.py
@@ -17,7 +17,17 @@
 
 import argparse
 from pathlib import Path
+from lstmcpipe.logging import setup_logging
 from lstmcpipe.io.data_management import query_continue
+from lstmcpipe.config import load_config, create_dl1ab_tuned_config
+from lstmcpipe.io.lstmcpipe_tree_path import (
+    create_log_files,
+    update_scancel_file,
+)
+from lstmcpipe.workflow_management import (
+    create_dl1_filenames_dict,
+    batch_mc_production_check,
+)
 from lstmcpipe.stages import (
     batch_process_dl1,
     batch_merge_and_copy_dl1,
@@ -27,14 +37,6 @@ from lstmcpipe.stages import (
     batch_dl2_to_sensitivity,
     batch_plot_rf_features,
 )
-from lstmcpipe.workflow_management import (
-    create_dl1_filenames_dict,
-    batch_mc_production_check,
-    create_log_files,
-    update_scancel_file,
-)
-from lstmcpipe.config import load_config, create_dl1ab_tuned_config
-from lstmcpipe.logging import setup_logging
 
 
 parser = argparse.ArgumentParser(description="MC R0 to DL3 full pipeline")
@@ -142,8 +144,8 @@ def main():
     gamma_offs = config.get("gamma_offs")
     no_image_merging = config.get("merging_no_image")
 
-    # Create log files
-    logs_files, scancel_file = create_log_files(prod_id)
+    # Create log files and log directory
+    logs_files, scancel_file, logs_dir = create_log_files(prod_id)
 
     # Make sure the lstchain config is defined if needed
     # It is not exactly required if you process only up to dl1
@@ -329,7 +331,7 @@ def main():
         jobs_from_dl2_irf,
         jobs_from_dl2_sensitivity,
         prod_id,
-        scancel_file,
+        log_directory=logs_dir,
         prod_config_file=args.config_mc_prod,
         last_stage=stages_to_run[-1],
         batch_config=batch_config,

--- a/lstmcpipe/tests/test_workflow_management.py
+++ b/lstmcpipe/tests/test_workflow_management.py
@@ -24,35 +24,6 @@ def test_save_log_to_file():
     assert dummy_log["dummy_jobid"] == log["NoKEY"]["dummy_jobid"]
 
 
-def test_create_log_files():
-    from ..workflow_management import create_log_files
-    logs, scancel_file = create_log_files('dummy_prodID')
-
-    assert "log_file" in logs.keys()
-    assert "debug_file" in logs.keys()
-
-    assert isinstance(logs["log_file"], Path)
-    assert isinstance(logs["debug_file"], Path)
-    assert isinstance(scancel_file, Path)
-
-    assert scancel_file.exists()
-
-
-def test_update_scancel_file():
-    from ..workflow_management import create_log_files, update_scancel_file
-    _, scancel_file = create_log_files("dummy_prodID")
-
-    update_scancel_file(scancel_file, "1234")
-    with open(scancel_file) as f:
-        lines = f.readlines()
-    assert lines == ["scancel 1234"]
-
-    update_scancel_file(scancel_file, "5678")
-    with open(scancel_file) as f:
-        lines = f.readlines()
-    assert lines == ["scancel 1234,5678"]
-
-
 @pytest.fixture()
 def create_fake_dl1_structure(tmp_path):
     fake_dl1_dir = tmp_path.joinpath("DL1", "{}")

--- a/lstmcpipe/workflow_management.py
+++ b/lstmcpipe/workflow_management.py
@@ -4,6 +4,7 @@
 
 import os
 import yaml
+import shutil
 import logging
 from pathlib import Path
 
@@ -99,7 +100,7 @@ def batch_mc_production_check(
     jobids_from_dl2_to_irf,
     jobids_from_dl2_to_sensitivity,
     prod_id,
-    scancel_file,
+    log_directory,
     prod_config_file,
     last_stage,
     batch_config,
@@ -121,7 +122,7 @@ def batch_mc_production_check(
     jobids_from_dl1_to_dl2: str
     jobids_from_dl2_to_irf: str
     jobids_from_dl2_to_sensitivity: str
-    scancel_file: str  or Path
+    log_directory: Path
     prod_config_file: str
     last_stage: str
     batch_config: dict
@@ -166,15 +167,17 @@ def batch_mc_production_check(
     which_last_stage = jobids_stages[last_stage]
 
     # Save machine info into the check file
-    cmd_wrap = f"touch check_MC_{prod_id}.txt; "
+    check_prod_file = log_directory.joinpath(f"check_MC_{prod_id}.txt").name
+    save_lstmcpipe_config = log_directory.joinpath(f"config_MC_prod_{prod_id}.yml")
+
+    # Copy lstmcpipe config used
+    shutil.copyfile(Path(prod_config_file).resolve(), save_lstmcpipe_config)
+
+    cmd_wrap = f"touch {check_prod_file}; "
     cmd_wrap += (
         f"sacct --format=jobid,jobname,nodelist,cputime,state,exitcode,avediskread,maxdiskread,avediskwrite,"
-        f"maxdiskwrite,AveVMSize,MaxVMSize,avecpufreq,reqmem -j {all_pipeline_jobs} >> "
-        f"check_MC_{prod_id}.txt; mkdir -p logs_{prod_id}; "
-        f"rm {scancel_file}; "
-        f"cp {Path(prod_config_file).resolve()} logs_{prod_id}/config_MC_prod_{prod_id}.yml; "
-        f"mv slurm-* check_MC_{prod_id}.txt {logs_files['log_file']} {logs_files['debug_file']}"
-        f" IRFFITSWriter.provenance.log logs_{prod_id};"
+        f"maxdiskwrite,AveVMSize,MaxVMSize,avecpufreq,reqmem -j {all_pipeline_jobs} >> {check_prod_file}; "
+        f"mv slurm-* IRFFITSWriter.provenance.log {log_directory.name};"
     )
 
     batch_cmd = "sbatch -p short --parsable"
@@ -204,68 +207,3 @@ def batch_mc_production_check(
                      workflow_step="check_full_workflow")
 
     return jobid
-
-
-def create_log_files(production_id):
-    """
-    Manages filenames (and overwrites if needed) log files.
-
-    Parameters
-    ----------
-    production_id : str
-        production identifier of the MC production to be launched
-
-    Returns
-    -------
-    logs_files: dict
-        Dictionary containing
-            log_file: Path - path and filename of full log file
-            debug_file: Path - path and filename of reduced (debug) log file
-    scancel_file: Path
-        path and filename of bash file to cancel all the scheduled jobs
-    """
-    import lstmcpipe
-    log_file = Path(f"./log_lstmcpipe_v{lstmcpipe.__version__}_{production_id}.yml")
-    debug_file = Path(f"./log_reduced_{production_id}.yml")
-    scancel_file = Path(f"./scancel_{production_id}.sh")
-
-    # scancel prod file needs chmod +x rights !
-    if scancel_file.exists():
-        scancel_file.unlink()
-    scancel_file.touch()
-    scancel_file.chmod(0o755)  # -rwxr-xr-x
-
-    # If the file exists, i,e., the pipeline has been relaunched, erase it
-    if log_file.exists():
-        log_file.unlink()
-    if debug_file.exists():
-        debug_file.unlink()
-
-    logs_files = {
-        "log_file": log_file,
-        "debug_file": debug_file
-    }
-
-    return logs_files, scancel_file
-
-
-def update_scancel_file(scancel_file, jobids_to_update):
-    """
-    Bash file containing the slurm command to cancel multiple jobs.
-    The file will be updated after every batched stage and will be erased in case the whole MC prod succeed without
-    errors.
-
-    Parameters
-    ----------
-    scancel_file: pathlib.Path
-        filename that cancels the whole MC production
-    jobids_to_update: str
-        job_ids to be included into the the file
-    """
-    if scancel_file.stat().st_size == 0:
-        with open(scancel_file, "r+") as f:
-            f.write(f"scancel {jobids_to_update}")
-
-    else:
-        with open(scancel_file, "a") as f:
-            f.write(f",{jobids_to_update}")


### PR DESCRIPTION
Every launched prod will save log, slurm and config files to this dir.

`create_log_files` and `update_scancel_file` moved from `workflow_management` to `io` submodule.

