### PR TITLE
add doc page with pipelines

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ extensions = [
     "sphinx_automodapi.automodapi",
     "sphinxarg.ext",
     "sphinx.ext.napoleon",
+    "sphinxcontrib.mermaid"
 ]
 
 autosummary_generate = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ lstmcpipe API documentation
    :maxdepth: 3
 
    productions
+   pipeline
    api/lstmcpipe
 
 

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -1,0 +1,51 @@
+lstmcpipe pipelines
+===================
+
+
+standard pipeline
+-----------------
+
+This is the typical MC pipeline
+
+..mermaid::
+
+    graph LR
+        subgraph R0
+            gamma
+            proton
+            electron
+        end
+
+        gamma --> r0dl1((r0_to_dl1))
+        proton --> r0dl1
+        electron --> r0dl1
+
+        subgraph DL1
+            gamma_dl1
+            proton_dl1
+            electron_dl1
+        end
+
+        r0dl1 --> gamma_dl1[DL1 gamma]
+        r0dl1 --> proton_dl1[DL1 proton]
+        r0dl1 --> electron_dl1[DL1 electron]
+
+
+        gamma_dl1 --> train_test_split((train_test_split))
+        proton_dl1 --> train_test_split
+        train_test_split --> DL1train[DL1 train]
+        train_test_split --> DL1test[DL1 test]
+        DL1train --> train_pipe((train_pipe))
+        train_pipe --> models
+
+        electron_dl1 --> DL1test
+
+        DL1train --> |dl1ab| DL1train
+        DL1test --> |dl1ab| DL1test
+
+        models --> DL2
+        DL1test --> DL2[DL2 test]
+
+        DL2 --> |dl2_to_irf| IRF[IRFs]
+        DL2 --> |dl2_to_sensitivity| SENS[Sensitivity]
+        SENS --> plot[png plots]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ sphinx-argparse
 sphinxcontrib-napoleon
 GitPython
 tabulate
+sphinxcontrib-mermaid


### PR DESCRIPTION
Add a documentation page with the pipeline graph:

```mermaid
graph LR
    subgraph R0
        gamma
        proton
        electron
    end

    gamma --> r0dl1((r0_to_dl1))
    proton --> r0dl1
    electron --> r0dl1

    subgraph DL1
        gamma_dl1
        proton_dl1
        electron_dl1
    end

    r0dl1 --> gamma_dl1[DL1 gamma]
    r0dl1 --> proton_dl1[DL1 proton]
    r0dl1 --> electron_dl1[DL1 electron]
   

    gamma_dl1 --> train_test_split((train_test_split))
    proton_dl1 --> train_test_split
    train_test_split --> DL1train[DL1 train]
    train_test_split --> DL1test[DL1 test]
    DL1train --> train_pipe((train_pipe))
    train_pipe --> models

    electron_dl1 --> DL1test

    DL1train --> |dl1ab| DL1train
    DL1test --> |dl1ab| DL1test

    models --> DL2
    DL1test --> DL2[DL2 test]

    DL2 --> |dl2_to_irf| IRF[IRFs]
    DL2 --> |dl2_to_sensitivity| SENS[Sensitivity]
    SENS --> plot[png plots]
```

Can be completed with new pipelines in the future.