### PR TITLE
Modify AllSky tree

### DIFF
--- a/lstmcpipe/config/paths_config.py
+++ b/lstmcpipe/config/paths_config.py
@@ -416,7 +416,7 @@ class PathConfigAllSky(PathConfig):
     def __init__(self, prod_id):
         super().__init__(prod_id)
         self.prod_id = prod_id
-        self.base_dir = "/fefs/aswg/data/mc/{data_level}/AllSky/{prod_id}/{particle}/{pointing}"
+        self.base_dir = "/fefs/aswg/data/mc/AllSky/{data_level}/{prod_id}/{particle}/{pointing}"
         self.training_dir = \
             "/home/georgios.voutsinas/ws/AllSky/TrainingDataset/{particle}/sim_telarray/{pointing}/output"
         self.testing_dir = "/home/georgios.voutsinas/ws/AllSky/TestDataset/Crab/sim_telarray/{pointing}/output"


### PR DESCRIPTION
I think it makes much more sense now to organise the tree production wise, and so to have:
```
data/mc/
└── AllSky
    └── DL0
        ├── TestDataset
        └── TrainingDataset
    └── DL1
        ├── TestDataset
        └── TrainingDataset
    └── DL2
        ├── TestDataset
        └── TrainingDataset
```

rather than
```
data/mc/
├── DL0
│   └── AllSky
├── DL1
│   └── AllSky
├── DL2
│   └── AllSky
```
