### PR TITLE
Raise memory requirement to 60GB by default

### DIFF
--- a/lstmcpipe/config/paths_config.py
+++ b/lstmcpipe/config/paths_config.py
@@ -770,7 +770,7 @@ class PathConfigAllSkyTesting(PathConfigAllSkyBase):
                     'input': self.testing_merged_dl1(pointing),
                     'path_model': self.models_dir(),
                     'output': self.dl2_dir(pointing),
-                    'slurm_options': '--mem=80GB' if self.dec == _crab_dec else '--mem=50GB'
+                    'slurm_options': '--mem=80GB' if self.dec == _crab_dec else '--mem=60GB'
                 }
             )
         return paths


### PR DESCRIPTION
A few (3) dl1_to_dl2 jobs failed to lack of RAM.
This raises the requirement to be on the safe side.
In the future, lstchain should require less memory with the refactoring of the RFs application.
