### PR TITLE
Request 4GB memory for IRF production

### DIFF
--- a/lstmcpipe/config/paths_config.py
+++ b/lstmcpipe/config/paths_config.py
@@ -793,6 +793,7 @@ class PathConfigAllSkyTesting(PathConfigAllSkyBase):
                     },
                     'output': os.path.join(self.irf_dir(pointing), f'irf_{self.prod_id}_{pointing}.fits.gz'),
                     'options': '--point-like',
+                    'slurm_options': '--mem=4GB'
                 }
             )
 

--- a/lstmcpipe/scripts/useful_tmp_scripts/rerun_irfs_mem_issue.py
+++ b/lstmcpipe/scripts/useful_tmp_scripts/rerun_irfs_mem_issue.py
@@ -1,0 +1,36 @@
+"""
+Run python rerun_irfs_mem_issue.py lstmcpipe_config.yaml
+"""
+from ruamel.yaml import YAML
+import sys
+from pathlib import Path
+
+
+yaml = YAML()
+
+filename = sys.argv[1]
+
+cfg = yaml.load(open(filename).read())
+
+cfg['stages_to_run'] = ['dl2_to_irfs']
+cfg['stages'].pop('r0_to_dl1')
+cfg['stages'].pop('merge_dl1')
+cfg['stages'].pop('train_pipe')
+cfg['stages'].pop('dl1_to_dl2')
+
+to_rerun = []
+for p in cfg['stages']['dl2_to_irfs']:
+    if not Path(p['output']).is_file():
+        print(p['output'])
+        p['slurm_options'] = '--mem=4GB'
+        to_rerun.append(p)
+
+cfg['stages']['dl2_to_irfs'] = to_rerun
+print(f"{len(to_rerun)} irfs to re-produce")
+
+output_filename = filename.replace('.yaml', '_rerun.yaml')
+if to_rerun and not Path(output_filename).exists():
+    print(f"Run lstmcpipe -c {output_filename}")
+    yaml.dump(cfg, open(output_filename, 'w'))
+elif Path(output_filename).exists():
+    raise FileExistsError(output_filename)


### PR DESCRIPTION
Fixes #309 

The script should be run for every recent AllSky production.
Slurm seems down at the moment
```
slurm_load_jobs error: Unable to contact slurm controller (connect failure)
```