### PR TITLE
default options before all other options

### DIFF
--- a/lstmcpipe/config/paths_config.py
+++ b/lstmcpipe/config/paths_config.py
@@ -630,7 +630,7 @@ class PathConfigAllSkyTraining(PathConfigAllSkyBase):
                     'input': dl1,
                     'output': merged_dl1,
                     'options': '--pattern */*.h5 --no-image',
-                    'slurm_options': '-p long',
+                    'extra_slurm_options': {'partition': 'long'},
                 }
             )
         return paths
@@ -644,8 +644,12 @@ class PathConfigAllSkyTraining(PathConfigAllSkyBase):
                     'proton': self.training_merged_dl1('Protons'),
                 },
                 'output': self.models_dir(),
-                'slurm_options': '-p xxl --mem=160G --cpus-per-task=16' if self.dec == _crab_dec
-                else '-p xxl --mem=100G --cpus-per-task=16',
+                'extra_slurm_options': {'partition': 'xxl',
+                                        'mem': '160G',
+                                        'cpus-per-task': 16} if self.dec == _crab_dec
+                else {'partition': 'xxl',
+                      'mem': '100G',
+                      'cpus-per-task': 16}
             }
         ]
         return paths
@@ -793,7 +797,7 @@ class PathConfigAllSkyTesting(PathConfigAllSkyBase):
                     'input': self.testing_merged_dl1(pointing),
                     'path_model': self.models_dir(),
                     'output': self.dl2_dir(pointing),
-                    'slurm_options': '--mem=80GB' if self.dec == _crab_dec else '--mem=60GB'
+                    'extra_slurm_options': {'mem': '80GB' if self.dec == _crab_dec else '60GB'}
                 }
             )
         return paths
@@ -816,7 +820,7 @@ class PathConfigAllSkyTesting(PathConfigAllSkyBase):
                     },
                     'output': os.path.join(self.irf_dir(pointing), f'irf_{self.prod_id}_{pointing}.fits.gz'),
                     'options': '--point-like',
-                    'slurm_options': '--mem=6GB'
+                    'extra_slurm_options': {'mem':'6GB'}
                 }
             )
 

--- a/lstmcpipe/scripts/generate_test_lapalma.py
+++ b/lstmcpipe/scripts/generate_test_lapalma.py
@@ -105,13 +105,13 @@ def generate_test_allsky(
     pc.generate()
     for stage_name, stage_steps in pc.paths.items():
         for step in stage_steps:
-            step['slurm_options'] = '-p short'
+            step['extra_slurm_options'] = {'partition': 'short'}
     pc.save_yml(os.path.join(path_to_config_file, f'test_AllSky_{date.today()}.yaml'), overwrite=overwrite)
     
     pcdl1ab.generate()
     for stage_name, stage_steps in pcdl1ab.paths.items():
         for step in stage_steps:
-            step['slurm_options'] = '-p short'
+            step['extra_slurm_options'] = {'partition': 'short'}
     pcdl1ab.save_yml(os.path.join(path_to_config_file, f'test_AllSky_{date.today()}_dl1ab.yaml'), overwrite=overwrite)
 
 

--- a/lstmcpipe/scripts/useful_tmp_scripts/rerun_irfs_mem_issue.py
+++ b/lstmcpipe/scripts/useful_tmp_scripts/rerun_irfs_mem_issue.py
@@ -1,6 +1,7 @@
 """
 Run python rerun_irfs_mem_issue.py lstmcpipe_config.yaml
 """
+
 from ruamel.yaml import YAML
 import sys
 from pathlib import Path
@@ -29,7 +30,7 @@ cfg['stages']['dl2_to_irfs'] = to_rerun
 print(f"{len(to_rerun)} irfs to re-produce")
 
 
-output_filename = filename.parent.joinpath(filename.stem + '_rerun.yaml')
+output_filename = filename.parent.joinpath(f'{filename.stem}_rerun.yaml')
 
 if to_rerun and not Path(output_filename).exists():
     print(f"Run lstmcpipe -c {output_filename}")

--- a/lstmcpipe/scripts/useful_tmp_scripts/rerun_irfs_mem_issue.py
+++ b/lstmcpipe/scripts/useful_tmp_scripts/rerun_irfs_mem_issue.py
@@ -22,7 +22,7 @@ to_rerun = []
 for p in cfg['stages']['dl2_to_irfs']:
     if not Path(p['output']).is_file():
         print(p['output'])
-        p['slurm_options'] = '--mem=6GB'
+        p['extra_slurm_options'] = {'mem':'6GB'}
         to_rerun.append(p)
 
 cfg['stages']['dl2_to_irfs'] = to_rerun

--- a/lstmcpipe/stages/mc_dl1_to_dl2.py
+++ b/lstmcpipe/stages/mc_dl1_to_dl2.py
@@ -6,17 +6,10 @@ from pathlib import Path
 from ..utils import save_log_to_file, SbatchLstMCStage
 from ..io.data_management import check_and_make_dir_without_verification
 
-
 log = logging.getLogger(__name__)
 
 
-def batch_dl1_to_dl2(
-    dict_paths,
-    config_file,
-    jobid_from_training,
-    batch_config,
-    logs,
-):
+def batch_dl1_to_dl2(dict_paths, config_file, jobid_from_training, batch_config, logs):
     """
     Function to batch the dl1_to_dl2 stage once the lstchain train_pipe batched jobs have finished.
 
@@ -41,50 +34,31 @@ def batch_dl1_to_dl2(
         string containing the jobids to be passed to the next stage of the workflow (as a slurm dependency_type)
 
     """
-
     log_dl1_to_dl2 = {}
     jobid_for_dl2_to_dl3 = []
     debug_log = {}
-
-    log.info("==== START {} ==== \n".format("batch dl1_to_dl2_workflow"))
-
+    log.info(f"==== START batch dl1_to_dl2_workflow ==== \n")
     for paths in dict_paths:
-
-        job_logs, jobid = dl1_to_dl2(
-            paths["input"],
-            paths["output"],
-            path_models=paths["path_model"],
-            config_file=config_file,
-            wait_jobid_train_pipe=jobid_from_training,
-            batch_configuration=batch_config,
-            extra_slurm_options=paths.get("extra_slurm_options", None),
-        )
+        job_logs, jobid = dl1_to_dl2(paths["input"], paths["output"],
+                                     path_models=paths["path_model"],
+                                     config_file=config_file,
+                                     wait_jobid_train_pipe=jobid_from_training,
+                                     batch_configuration=batch_config,
+                                     extra_slurm_options=paths.get("extra_slurm_options", None))
 
         log_dl1_to_dl2.update(job_logs)
-
-        # Single particle dl1_dl2 jobid to be appended
         jobid_for_dl2_to_dl3.append(jobid)
         debug_log[jobid] = f"dl1_to_dl2 jobid that depends on : {jobid_from_training} training job"
 
     jobid_for_dl2_to_dl3 = ",".join(jobid_for_dl2_to_dl3)
-
     save_log_to_file(log_dl1_to_dl2, logs["log_file"], workflow_step="dl1_to_dl2")
     save_log_to_file(debug_log, logs["debug_file"], workflow_step="dl1_to_dl2")
-
-    log.info("==== END {} ====".format("batch dl1_to_dl2_workflow"))
-
+    log.info("==== END batch dl1_to_dl2_workflow ====")
     return jobid_for_dl2_to_dl3
 
 
-def dl1_to_dl2(
-    input_file,
-    output_dir,
-    path_models,
-    config_file,
-    wait_jobid_train_pipe=None,
-    batch_configuration='',
-    extra_slurm_options=None,
-):
+def dl1_to_dl2(input_file, output_dir, path_models, config_file, wait_jobid_train_pipe=None, batch_configuration='',
+               extra_slurm_options=None):
     """
     Convert onsite files from dl1 to dl2
 
@@ -117,34 +91,24 @@ def dl1_to_dl2(
         batched job_id to be passed to later stages
 
     """
-    log.info("Working on DL1 files in {}".format(Path(input_file).parent.as_posix()))
-
+    log.info(f"Working on DL1 files in {Path(input_file).parent.as_posix()}")
     check_and_make_dir_without_verification(output_dir)
-    log.info("Output dir: {}".format(output_dir))
-
-    log_dl1_to_dl2 = {}
-
-    cmd = f"lstchain_dl1_to_dl2 -f {input_file} -p {path_models}" f" -o {output_dir}"
+    log.info(f"Output dir: {output_dir}")
+    cmd = f"lstchain_dl1_to_dl2 -f {input_file} -p {path_models} -o {output_dir}"
     if config_file is not None:
         cmd += f" -c {Path(config_file).resolve().as_posix()}"
-
-    sbatch_dl1_dl2 = SbatchLstMCStage(
-        "dl1_to_dl2",  # default: -p short --mem=32G
-        wrap_command=cmd,
-        slurm_error=Path(output_dir).joinpath("dl1_dl2-%j.e").resolve().as_posix(),
-        slurm_output=Path(output_dir).joinpath("dl1_dl2-%j.o").resolve().as_posix(),
-        slurm_dependencies=wait_jobid_train_pipe,
-        extra_slurm_options=extra_slurm_options,
-        slurm_account=batch_configuration["slurm_account"],
-        source_environment=batch_configuration["source_environment"],
-    )
+    sbatch_dl1_dl2 = SbatchLstMCStage("dl1_to_dl2",
+                                      wrap_command=cmd,
+                                      slurm_error=Path(output_dir).joinpath("dl1_dl2-%j.e").resolve().as_posix(),
+                                      slurm_output=Path(output_dir).joinpath("dl1_dl2-%j.o").resolve().as_posix(),
+                                      slurm_dependencies=wait_jobid_train_pipe,
+                                      extra_slurm_options=extra_slurm_options,
+                                      slurm_account=batch_configuration["slurm_account"],
+                                      source_environment=batch_configuration["source_environment"])
 
     jobid_dl1_to_dl2 = sbatch_dl1_dl2.submit()
-    log_dl1_to_dl2.update({jobid_dl1_to_dl2: sbatch_dl1_dl2.slurm_command})
-
+    log_dl1_to_dl2 = {jobid_dl1_to_dl2: sbatch_dl1_dl2.slurm_command}
     log.info(f"Submitted batch job {jobid_dl1_to_dl2}")
-
     if config_file is not None:
         shutil.copyfile(config_file, Path(output_dir).joinpath(Path(config_file).name))
-
     return log_dl1_to_dl2, jobid_dl1_to_dl2

--- a/lstmcpipe/stages/mc_dl1_to_dl2.py
+++ b/lstmcpipe/stages/mc_dl1_to_dl2.py
@@ -21,7 +21,7 @@ def batch_dl1_to_dl2(dict_paths, config_file, jobid_from_training, batch_config,
         Path to a configuration file. If none is given, a standard configuration is applied
     jobid_from_training : str
         string containing the jobid from the jobs batched in the train_pipe stage, to be passed to the
-        dl1_to_dl2 function (as a slurm dependency_type)
+        dl1_to_dl2 function (as a slurm dependency)
     batch_config : dict
         Dictionary containing the (full) source_environment and the slurm_account strings to be passed to
         dl1_dl2 function
@@ -31,7 +31,7 @@ def batch_dl1_to_dl2(dict_paths, config_file, jobid_from_training, batch_config,
     Returns
     -------
     jobid_for_dl2_to_dl3 : str
-        string containing the jobids to be passed to the next stage of the workflow (as a slurm dependency_type)
+        string containing the jobids to be passed to the next stage of the workflow (as a slurm dependency)
 
     """
     log_dl1_to_dl2 = {}

--- a/lstmcpipe/stages/mc_dl1_to_dl2.py
+++ b/lstmcpipe/stages/mc_dl1_to_dl2.py
@@ -37,7 +37,7 @@ def batch_dl1_to_dl2(dict_paths, config_file, jobid_from_training, batch_config,
     log_dl1_to_dl2 = {}
     jobid_for_dl2_to_dl3 = []
     debug_log = {}
-    log.info(f"==== START batch dl1_to_dl2_workflow ==== \n")
+    log.info("==== START batch dl1_to_dl2_workflow ==== \n")
     for paths in dict_paths:
         job_logs, jobid = dl1_to_dl2(paths["input"], paths["output"],
                                      path_models=paths["path_model"],

--- a/lstmcpipe/stages/mc_dl1_to_dl2.py
+++ b/lstmcpipe/stages/mc_dl1_to_dl2.py
@@ -39,12 +39,15 @@ def batch_dl1_to_dl2(dict_paths, config_file, jobid_from_training, batch_config,
     debug_log = {}
     log.info("==== START batch dl1_to_dl2_workflow ==== \n")
     for paths in dict_paths:
-        job_logs, jobid = dl1_to_dl2(paths["input"], paths["output"],
-                                     path_models=paths["path_model"],
-                                     config_file=config_file,
-                                     wait_jobid_train_pipe=jobid_from_training,
-                                     batch_configuration=batch_config,
-                                     extra_slurm_options=paths.get("extra_slurm_options", None))
+        job_logs, jobid = dl1_to_dl2(
+            paths["input"],
+            paths["output"],
+            path_models=paths["path_model"],
+            config_file=config_file,
+            wait_jobid_train_pipe=jobid_from_training,
+            batch_configuration=batch_config,
+            extra_slurm_options=paths.get("extra_slurm_options", None),
+        )
 
         log_dl1_to_dl2.update(job_logs)
         jobid_for_dl2_to_dl3.append(jobid)
@@ -57,8 +60,15 @@ def batch_dl1_to_dl2(dict_paths, config_file, jobid_from_training, batch_config,
     return jobid_for_dl2_to_dl3
 
 
-def dl1_to_dl2(input_file, output_dir, path_models, config_file, wait_jobid_train_pipe=None, batch_configuration='',
-               extra_slurm_options=None):
+def dl1_to_dl2(
+    input_file,
+    output_dir,
+    path_models,
+    config_file,
+    wait_jobid_train_pipe=None,
+    batch_configuration='',
+    extra_slurm_options=None,
+):
     """
     Convert onsite files from dl1 to dl2
 
@@ -97,14 +107,16 @@ def dl1_to_dl2(input_file, output_dir, path_models, config_file, wait_jobid_trai
     cmd = f"lstchain_dl1_to_dl2 -f {input_file} -p {path_models} -o {output_dir}"
     if config_file is not None:
         cmd += f" -c {Path(config_file).resolve().as_posix()}"
-    sbatch_dl1_dl2 = SbatchLstMCStage("dl1_to_dl2",
-                                      wrap_command=cmd,
-                                      slurm_error=Path(output_dir).joinpath("dl1_dl2-%j.e").resolve().as_posix(),
-                                      slurm_output=Path(output_dir).joinpath("dl1_dl2-%j.o").resolve().as_posix(),
-                                      slurm_dependencies=wait_jobid_train_pipe,
-                                      extra_slurm_options=extra_slurm_options,
-                                      slurm_account=batch_configuration["slurm_account"],
-                                      source_environment=batch_configuration["source_environment"])
+    sbatch_dl1_dl2 = SbatchLstMCStage(
+        "dl1_to_dl2",
+        wrap_command=cmd,
+        slurm_error=Path(output_dir).joinpath("dl1_dl2-%j.e").resolve().as_posix(),
+        slurm_output=Path(output_dir).joinpath("dl1_dl2-%j.o").resolve().as_posix(),
+        slurm_dependencies=wait_jobid_train_pipe,
+        extra_slurm_options=extra_slurm_options,
+        slurm_account=batch_configuration["slurm_account"],
+        source_environment=batch_configuration["source_environment"],
+    )
 
     jobid_dl1_to_dl2 = sbatch_dl1_dl2.submit()
     log_dl1_to_dl2 = {jobid_dl1_to_dl2: sbatch_dl1_dl2.slurm_command}

--- a/lstmcpipe/stages/mc_dl1_to_dl2.py
+++ b/lstmcpipe/stages/mc_dl1_to_dl2.py
@@ -28,7 +28,7 @@ def batch_dl1_to_dl2(
         Path to a configuration file. If none is given, a standard configuration is applied
     jobid_from_training : str
         string containing the jobid from the jobs batched in the train_pipe stage, to be passed to the
-        dl1_to_dl2 function (as a slurm dependency)
+        dl1_to_dl2 function (as a slurm dependency_type)
     batch_config : dict
         Dictionary containing the (full) source_environment and the slurm_account strings to be passed to
         dl1_dl2 function
@@ -38,7 +38,7 @@ def batch_dl1_to_dl2(
     Returns
     -------
     jobid_for_dl2_to_dl3 : str
-        string containing the jobids to be passed to the next stage of the workflow (as a slurm dependency)
+        string containing the jobids to be passed to the next stage of the workflow (as a slurm dependency_type)
 
     """
 
@@ -57,7 +57,7 @@ def batch_dl1_to_dl2(
             config_file=config_file,
             wait_jobid_train_pipe=jobid_from_training,
             batch_configuration=batch_config,
-            slurm_options=paths.get("slurm_options", None),
+            extra_slurm_options=paths.get("extra_slurm_options", None),
         )
 
         log_dl1_to_dl2.update(job_logs)
@@ -83,7 +83,7 @@ def dl1_to_dl2(
     config_file,
     wait_jobid_train_pipe=None,
     batch_configuration='',
-    slurm_options=None,
+    extra_slurm_options=None,
 ):
     """
     Convert onsite files from dl1 to dl2
@@ -105,7 +105,7 @@ def dl1_to_dl2(
         Dictionary containing the (full) source_environment and the slurm_account strings
         to be passed to the sbatch commands
         ! NOTE : train_pipe AND dl1_to_dl2 MUST BE RUN WITH THE SAME ENVIRONMENT
-    slurm_options: str
+    extra_slurm_options: dict
         Extra slurm options to be passed to the sbatch command
 
     Returns
@@ -133,8 +133,8 @@ def dl1_to_dl2(
         wrap_command=cmd,
         slurm_error=Path(output_dir).joinpath("dl1_dl2-%j.e").resolve().as_posix(),
         slurm_output=Path(output_dir).joinpath("dl1_dl2-%j.o").resolve().as_posix(),
-        slurm_deps=wait_jobid_train_pipe,
-        slurm_options=slurm_options,
+        slurm_dependencies=wait_jobid_train_pipe,
+        extra_slurm_options=extra_slurm_options,
         slurm_account=batch_configuration["slurm_account"],
         source_environment=batch_configuration["source_environment"],
     )

--- a/lstmcpipe/stages/mc_dl2_to_irfs.py
+++ b/lstmcpipe/stages/mc_dl2_to_irfs.py
@@ -13,13 +13,7 @@ from ..io.data_management import check_and_make_dir_without_verification
 log = logging.getLogger(__name__)
 
 
-def batch_dl2_to_irfs(
-    dict_paths,
-    config_file,
-    job_ids_from_dl1_dl2,
-    batch_config,
-    logs,
-):
+def batch_dl2_to_irfs(dict_paths, config_file, job_ids_from_dl1_dl2, batch_config, logs):
     """
     Batches the dl2_to_irfs stage (lstchain lstchain_create_irf_files script) once the dl1_to_dl2 stage had finished.
 
@@ -53,7 +47,7 @@ def batch_dl2_to_irfs(
         job_logs, jobid = dl2_to_irfs(
             paths["input"]["gamma_file"],  # gamma_file must always be provided
             paths["input"].get("electron_file", None),  # electron_file might be missing in case of point-like IRFs
-            paths["input"].get("proton_file", None),   # proton_file might be missing in case of point-like IRFs
+            paths["input"].get("proton_file", None),  # proton_file might be missing in case of point-like IRFs
             paths["output"],
             config_file=config_file,
             options=paths.get("options", None),

--- a/lstmcpipe/stages/mc_dl2_to_irfs.py
+++ b/lstmcpipe/stages/mc_dl2_to_irfs.py
@@ -43,7 +43,7 @@ def batch_dl2_to_irfs(
     jobs_from_dl2_irf: str
         Comma-separated jobids batched in the current stage
     """
-    log.info("==== START {} ====".format("batch mc_dl2_to_irfs"))
+    log.info("==== START batch mc_dl2_to_irfs ====")
 
     log_dl2_to_irfs = {}
     jobid_for_check = []
@@ -73,7 +73,7 @@ def batch_dl2_to_irfs(
     save_log_to_file(log_dl2_to_irfs, logs["log_file"], workflow_step="dl2_to_irfs")
     save_log_to_file(debug_log, logs["debug_file"], workflow_step="dl2_to_irfs")
 
-    log.info("==== END {} ====".format("batch mc_dl2_to_irfs"))
+    log.info("==== END batch mc_dl2_to_irfs ====")
 
     return jobid_for_check
 

--- a/lstmcpipe/stages/mc_dl2_to_irfs.py
+++ b/lstmcpipe/stages/mc_dl2_to_irfs.py
@@ -30,7 +30,7 @@ def batch_dl2_to_irfs(
     config_file: str
         Path to lstchain-like config file
     job_ids_from_dl1_dl2: str
-        Comma-separated string with the job ids from the dl1_to_dl2 stage to be used as a slurm dependency_type
+        Comma-separated string with the job ids from the dl1_to_dl2 stage to be used as a slurm dependency
         to schedule the current stage
     batch_config : dict
         Dictionary containing the (full) source_environment and the slurm_account strings to be passed to

--- a/lstmcpipe/stages/mc_dl2_to_irfs.py
+++ b/lstmcpipe/stages/mc_dl2_to_irfs.py
@@ -30,7 +30,7 @@ def batch_dl2_to_irfs(
     config_file: str
         Path to lstchain-like config file
     job_ids_from_dl1_dl2: str
-        Comma-separated string with the job ids from the dl1_to_dl2 stage to be used as a slurm dependency
+        Comma-separated string with the job ids from the dl1_to_dl2 stage to be used as a slurm dependency_type
         to schedule the current stage
     batch_config : dict
         Dictionary containing the (full) source_environment and the slurm_account strings to be passed to
@@ -59,7 +59,7 @@ def batch_dl2_to_irfs(
             options=paths.get("options", None),
             batch_configuration=batch_config,
             wait_jobs_dl1dl2=job_ids_from_dl1_dl2,
-            slurm_options=paths.get("slurm_options", None),
+            extra_slurm_options=paths.get("extra_slurm_options", None),
         )
 
         log_dl2_to_irfs.update(log_dl2_to_irfs)
@@ -87,7 +87,7 @@ def dl2_to_irfs(
     options,
     batch_configuration,
     wait_jobs_dl1dl2,
-    slurm_options=None,
+    extra_slurm_options=None,
 ):
     """
     Batches interactively the lstchain `lstchain_create_irf_files` entry point.
@@ -109,7 +109,7 @@ def dl2_to_irfs(
     wait_jobs_dl1dl2: str
         Comma separated string with the job ids of previous stages (dl1_to_dl2 stage) to be passed as dependencies to
         the create_irfs_files job to be batched.
-    slurm_options: str
+    extra_slurm_options: dict
         Extra slurm options to be passed to the sbatch command
 
     Returns
@@ -140,8 +140,8 @@ def dl2_to_irfs(
         wrap_command=cmd,
         slurm_error=Path(output_dir).joinpath("job_dl2_to_irfs-%j.e").resolve().as_posix(),
         slurm_output=Path(output_dir).joinpath("job_dl2_to_irfs-%j.o").resolve().as_posix(),
-        slurm_deps=wait_jobs_dl1dl2,
-        slurm_options=slurm_options,
+        slurm_dependencies=wait_jobs_dl1dl2,
+        extra_slurm_options=extra_slurm_options,
         slurm_account=batch_configuration["slurm_account"],
         source_environment=batch_configuration["source_environment"],
     )

--- a/lstmcpipe/stages/mc_dl2_to_sensitivity.py
+++ b/lstmcpipe/stages/mc_dl2_to_sensitivity.py
@@ -17,7 +17,7 @@ def batch_dl2_to_sensitivity(dict_paths, job_ids_from_dl1_dl2, batch_config, log
     dict_paths : dict
         Core dictionary with {stage: PATHS} information
     job_ids_from_dl1_dl2: str
-        Comma-separated string with the job ids from the dl1_to_dl2 stage to be used as a slurm dependency_type
+        Comma-separated string with the job ids from the dl1_to_dl2 stage to be used as a slurm dependency
         to schedule the current stage
     batch_config : dict
         Dictionary containing the (full) source_environment and the slurm_account strings to be passed to
@@ -68,7 +68,7 @@ def dl2_to_sensitivity(input_paths, output, batch_configuration, wait_jobs_dl1_d
         Dictionary containing the (full) source_environment and the slurm_account strings to be passed to the
         sbatch commands
     wait_jobs_dl1_dl2: str
-        Comma-separated string with the jobs (dependency_type) to wait for before launching the cmd
+        Comma-separated string with the jobs (dependency) to wait for before launching the cmd
     extra_slurm_options: dict
         Extra slurm options to be passed to the sbatch command
 

--- a/lstmcpipe/stages/mc_dl2_to_sensitivity.py
+++ b/lstmcpipe/stages/mc_dl2_to_sensitivity.py
@@ -23,7 +23,7 @@ def batch_dl2_to_sensitivity(
     dict_paths : dict
         Core dictionary with {stage: PATHS} information
     job_ids_from_dl1_dl2: str
-        Comma-separated string with the job ids from the dl1_to_dl2 stage to be used as a slurm dependency
+        Comma-separated string with the job ids from the dl1_to_dl2 stage to be used as a slurm dependency_type
         to schedule the current stage
     batch_config : dict
         Dictionary containing the (full) source_environment and the slurm_account strings to be passed to
@@ -48,7 +48,7 @@ def batch_dl2_to_sensitivity(
             paths["output"],
             batch_configuration=batch_config,
             wait_jobs_dl1_dl2=job_ids_from_dl1_dl2,
-            slurm_options=paths.get("slurm_options", None),
+            extra_slurm_options=paths.get("extra_slurm_options", None),
         )
         jobid_for_check.append(jobid)
         log_dl2_to_sensitivity.update(job_logs)
@@ -72,7 +72,7 @@ def dl2_to_sensitivity(
     output,
     batch_configuration,
     wait_jobs_dl1_dl2,
-    slurm_options=None,
+    extra_slurm_options=None,
 ):
     """
     Function to run the `script_dl2_to_sensitivity` for the gamma (and the different gamma offsets) and gamma-diffuse
@@ -87,8 +87,8 @@ def dl2_to_sensitivity(
         Dictionary containing the (full) source_environment and the slurm_account strings to be passed to the
         sbatch commands
     wait_jobs_dl1_dl2: str
-        Comma-separated string with the jobs (dependency) to wait for before launching the cmd
-    slurm_options: str
+        Comma-separated string with the jobs (dependency_type) to wait for before launching the cmd
+    extra_slurm_options: dict
         Extra slurm options to be passed to the sbatch command
 
     Returns
@@ -113,8 +113,8 @@ def dl2_to_sensitivity(
         wrap_command=cmd_sens,
         slurm_error=Path(output).parent.joinpath("job_dl2_to_sensitivity.e"),
         slurm_output=Path(output).parent.joinpath("job_dl2_to_sensitivity.o"),
-        slurm_deps=wait_jobs_dl1_dl2,
-        slurm_options=slurm_options,
+        slurm_dependencies=wait_jobs_dl1_dl2,
+        extra_slurm_options=extra_slurm_options,
         slurm_account=batch_configuration["slurm_account"],
         source_environment=batch_configuration["source_environment"],
     )
@@ -134,8 +134,8 @@ def dl2_to_sensitivity(
         wrap_command=cmd_plot_sens,
         slurm_error=Path(output).parent.joinpath("job_plot_sensitivity-%j.e"),
         slurm_output=Path(output).parent.joinpath("job_plot_sensitivity-%j.o"),
-        slurm_deps=job_id_dl2_sens,
-        slurm_options=slurm_options,
+        slurm_dependencies=job_id_dl2_sens,
+        extra_slurm_options=extra_slurm_options,
         slurm_account=batch_configuration["slurm_account"],
         source_environment=batch_configuration["source_environment"],
         backend="export MPLBACKEND=Agg; ",

--- a/lstmcpipe/stages/mc_merge_dl1.py
+++ b/lstmcpipe/stages/mc_merge_dl1.py
@@ -39,10 +39,15 @@ def batch_merge_dl1(dict_paths, batch_config, logs, jobid_from_splitting, workfl
     debug_log = {}
     log.info('==== START batch merge_and_copy_dl1_workflow ====')
     for paths in dict_paths:
-        job_logs, jobid_debug = merge_dl1(paths["input"], paths["output"], merging_options=paths.get('options', None),
-                                          batch_configuration=batch_config, wait_jobs_split=jobid_from_splitting,
-                                          workflow_kind=workflow_kind,
-                                          extra_slurm_options=paths.get("extra_slurm_options", None))
+        job_logs, jobid_debug = merge_dl1(
+            paths["input"],
+            paths["output"],
+            merging_options=paths.get('options', None),
+            batch_configuration=batch_config,
+            wait_jobs_split=jobid_from_splitting,
+            workflow_kind=workflow_kind,
+            extra_slurm_options=paths.get("extra_slurm_options", None),
+        )
 
         log_merge.update(job_logs)
         all_jobs_merge_stage.append(jobid_debug)
@@ -52,8 +57,15 @@ def batch_merge_dl1(dict_paths, batch_config, logs, jobid_from_splitting, workfl
     return ','.join(all_jobs_merge_stage)
 
 
-def merge_dl1(input_dir, output_file, batch_configuration, wait_jobs_split="", merging_options=None,
-              workflow_kind="lstchain", extra_slurm_options=None):
+def merge_dl1(
+    input_dir,
+    output_file,
+    batch_configuration,
+    wait_jobs_split="",
+    merging_options=None,
+    workflow_kind="lstchain",
+    extra_slurm_options=None,
+):
     """
 
     Parameters
@@ -80,12 +92,16 @@ def merge_dl1(input_dir, output_file, batch_configuration, wait_jobs_split="", m
     else:
         cmd = f'ctapipe-merge --input-dir {input_dir} --output {output_file} {merging_options}'
 
-    sbatch_merge_dl1 = SbatchLstMCStage("merge_dl1", wrap_command=cmd,
-                                        slurm_error=Path(output_file).parent.joinpath("merging-output.e"),
-                                        slurm_output=Path(output_file).parent.joinpath("merging-output.o"),
-                                        slurm_dependencies=wait_jobs_split, extra_slurm_options=extra_slurm_options,
-                                        slurm_account=batch_configuration["slurm_account"],
-                                        source_environment=batch_configuration["source_environment"])
+    sbatch_merge_dl1 = SbatchLstMCStage(
+        "merge_dl1",
+        wrap_command=cmd,
+        slurm_error=Path(output_file).parent.joinpath("merging-output.e"),
+        slurm_output=Path(output_file).parent.joinpath("merging-output.o"),
+        slurm_dependencies=wait_jobs_split,
+        extra_slurm_options=extra_slurm_options,
+        slurm_account=batch_configuration["slurm_account"],
+        source_environment=batch_configuration["source_environment"],
+    )
 
     jobid_merge = sbatch_merge_dl1.submit()
     log_merge = {jobid_merge: sbatch_merge_dl1.slurm_command}

--- a/lstmcpipe/stages/mc_merge_dl1.py
+++ b/lstmcpipe/stages/mc_merge_dl1.py
@@ -37,7 +37,7 @@ def batch_merge_dl1(
     -------
     jobids_for_train : str
          Comma-separated str with all the job-ids to be passed to the next
-         stage of the workflow (as a slurm dependency)
+         stage of the workflow (as a slurm dependency_type)
 
     """
     log_merge = {}
@@ -61,7 +61,7 @@ def batch_merge_dl1(
             batch_configuration=batch_config,
             wait_jobs_split=jobid_from_splitting,
             workflow_kind=workflow_kind,
-            slurm_options=paths.get("slurm_options", None),
+            extra_slurm_options=paths.get("extra_slurm_options", None),
         )
 
         log_merge.update(job_logs)
@@ -84,7 +84,7 @@ def merge_dl1(
     wait_jobs_split="",
     merging_options=None,
     workflow_kind="lstchain",
-    slurm_options=None,
+    extra_slurm_options=None,
 ):
     """
 
@@ -96,7 +96,7 @@ def merge_dl1(
     wait_jobs_split: str
     merging_options: dict
     workflow_kind: str
-    slurm_options: str
+    extra_slurm_options: dict
         Extra slurm options to be passed to the sbatch command
 
     Returns
@@ -122,8 +122,8 @@ def merge_dl1(
         wrap_command=cmd,
         slurm_error=Path(output_file).parent.joinpath("merging-output.e"),
         slurm_output=Path(output_file).parent.joinpath("merging-output.o"),
-        slurm_deps=wait_jobs_split,
-        slurm_options=slurm_options,
+        slurm_dependencies=wait_jobs_split,
+        extra_slurm_options=extra_slurm_options,
         slurm_account=batch_configuration["slurm_account"],
         source_environment=batch_configuration["source_environment"],
     )

--- a/lstmcpipe/stages/mc_merge_dl1.py
+++ b/lstmcpipe/stages/mc_merge_dl1.py
@@ -7,13 +7,7 @@ from ..utils import save_log_to_file, SbatchLstMCStage
 log = logging.getLogger(__name__)
 
 
-def batch_merge_dl1(
-    dict_paths,
-    batch_config,
-    logs,
-    jobid_from_splitting,
-    workflow_kind="lstchain",
-):
+def batch_merge_dl1(dict_paths, batch_config, logs, jobid_from_splitting, workflow_kind="lstchain"):
     """
     Function to batch the onsite_mc_merge_and_copy function once the all the r0_to_dl1 jobs (batched by particle type)
     have finished.
@@ -43,49 +37,23 @@ def batch_merge_dl1(
     log_merge = {}
     all_jobs_merge_stage = []
     debug_log = {}
-
-    log.info("==== START {} ====".format("batch merge_and_copy_dl1_workflow"))
-    # TODO Lukas: merging option will come inside the
-    #  dict_paths["merge_dl1"]["merging_options"]
-    #    if isinstance(smart_merge, str):
-    #        merge_flag = "lst" in smart_merge
-    #    else:
-    #        merge_flag = smart_merge
-    #    log.debug("Merge flag set: {}".format(merge_flag))
-
+    log.info('==== START batch merge_and_copy_dl1_workflow ====')
     for paths in dict_paths:
-        job_logs, jobid_debug = merge_dl1(
-            paths["input"],
-            paths["output"],
-            merging_options=paths.get('options', None),
-            batch_configuration=batch_config,
-            wait_jobs_split=jobid_from_splitting,
-            workflow_kind=workflow_kind,
-            extra_slurm_options=paths.get("extra_slurm_options", None),
-        )
+        job_logs, jobid_debug = merge_dl1(paths["input"], paths["output"], merging_options=paths.get('options', None),
+                                          batch_configuration=batch_config, wait_jobs_split=jobid_from_splitting,
+                                          workflow_kind=workflow_kind,
+                                          extra_slurm_options=paths.get("extra_slurm_options", None))
 
         log_merge.update(job_logs)
         all_jobs_merge_stage.append(jobid_debug)
-
-    jobids_for_train = ','.join(all_jobs_merge_stage)
-
     save_log_to_file(log_merge, logs["log_file"], "merge_dl1")
     save_log_to_file(debug_log, logs["debug_file"], workflow_step="merge_dl1")
-
-    log.info("==== END {} ====".format("batch merge_and_copy_dl1_workflow"))
-
-    return jobids_for_train
+    log.info('==== END batch merge_and_copy_dl1_workflow ====')
+    return ','.join(all_jobs_merge_stage)
 
 
-def merge_dl1(
-    input_dir,
-    output_file,
-    batch_configuration,
-    wait_jobs_split="",
-    merging_options=None,
-    workflow_kind="lstchain",
-    extra_slurm_options=None,
-):
+def merge_dl1(input_dir, output_file, batch_configuration, wait_jobs_split="", merging_options=None,
+              workflow_kind="lstchain", extra_slurm_options=None):
     """
 
     Parameters
@@ -106,32 +74,21 @@ def merge_dl1(
 
     """
     merging_options = "" if merging_options is None else merging_options
-    log_merge = {}
+    if workflow_kind in ["lstchain", "hiperta"]:
+        cmd = f'lstchain_merge_hdf5_files -d {input_dir} -o {output_file} {merging_options}'
 
-    # command passed changes depending on the workflow_kind
-    if workflow_kind == "lstchain":
-        cmd = f'lstchain_merge_hdf5_files -d {input_dir} -o {output_file} {merging_options}'
-    elif workflow_kind == "hiperta":
-        # HiPeRTA workflow still uses --smart flag (lstchain v0.6.3)
-        cmd = f'lstchain_merge_hdf5_files -d {input_dir} -o {output_file} {merging_options}'
-    else:  # ctapipe case
+    else:
         cmd = f'ctapipe-merge --input-dir {input_dir} --output {output_file} {merging_options}'
 
-    sbatch_merge_dl1 = SbatchLstMCStage(
-        "merge_dl1",
-        wrap_command=cmd,
-        slurm_error=Path(output_file).parent.joinpath("merging-output.e"),
-        slurm_output=Path(output_file).parent.joinpath("merging-output.o"),
-        slurm_dependencies=wait_jobs_split,
-        extra_slurm_options=extra_slurm_options,
-        slurm_account=batch_configuration["slurm_account"],
-        source_environment=batch_configuration["source_environment"],
-    )
+    sbatch_merge_dl1 = SbatchLstMCStage("merge_dl1", wrap_command=cmd,
+                                        slurm_error=Path(output_file).parent.joinpath("merging-output.e"),
+                                        slurm_output=Path(output_file).parent.joinpath("merging-output.o"),
+                                        slurm_dependencies=wait_jobs_split, extra_slurm_options=extra_slurm_options,
+                                        slurm_account=batch_configuration["slurm_account"],
+                                        source_environment=batch_configuration["source_environment"])
 
     jobid_merge = sbatch_merge_dl1.submit()
-    log_merge.update({jobid_merge: sbatch_merge_dl1.slurm_command})
-
+    log_merge = {jobid_merge: sbatch_merge_dl1.slurm_command}
     log.info(f"\nMerging DL1 file from {input_dir} dir into {output_file} file.")
     log.info(f"Submitted batch job {jobid_merge}")
-
     return log_merge, jobid_merge

--- a/lstmcpipe/stages/mc_merge_dl1.py
+++ b/lstmcpipe/stages/mc_merge_dl1.py
@@ -31,7 +31,7 @@ def batch_merge_dl1(dict_paths, batch_config, logs, jobid_from_splitting, workfl
     -------
     jobids_for_train : str
          Comma-separated str with all the job-ids to be passed to the next
-         stage of the workflow (as a slurm dependency_type)
+         stage of the workflow (as a slurm dependency)
 
     """
     log_merge = {}

--- a/lstmcpipe/stages/mc_process_dl1.py
+++ b/lstmcpipe/stages/mc_process_dl1.py
@@ -48,18 +48,28 @@ def batch_process_dl1(dict_paths, conf_file, batch_config, logs, workflow_kind="
                 debug_log["**EMPTY_R0_DIR**"] = f'{paths["input"]} directory does not contain any simtel.gz file'
 
                 continue
-            job_logs, jobid = r0_to_dl1(paths["input"], paths["output"], config_file=conf_file,
-                                        batch_config=batch_config, workflow_kind=workflow_kind,
-                                        extra_slurm_options=paths.get("extra_slurm_options", None))
+            job_logs, jobid = r0_to_dl1(
+                paths["input"],
+                paths["output"],
+                config_file=conf_file,
+                batch_config=batch_config,
+                workflow_kind=workflow_kind,
+                extra_slurm_options=paths.get("extra_slurm_options", None),
+            )
 
             log_process_dl1.update(job_logs)
             jobids_dl1_processing_stage.append(jobid)
             debug_log[jobid] = f'r0_dl1 job from input dir: {paths["input"]}'
     else:
         for paths in dict_paths["dl1ab"]:
-            job_logs, jobid = reprocess_dl1(paths["input"], paths["output"], config_file=conf_file,
-                                            batch_config=batch_config, workflow_kind=workflow_kind,
-                                            extra_slurm_options=paths.get("extra_slurm_options", None))
+            job_logs, jobid = reprocess_dl1(
+                paths["input"],
+                paths["output"],
+                config_file=conf_file,
+                batch_config=batch_config,
+                workflow_kind=workflow_kind,
+                extra_slurm_options=paths.get("extra_slurm_options", None),
+            )
 
             log_process_dl1.update(job_logs)
             jobids_dl1_processing_stage.append(jobid)
@@ -71,8 +81,16 @@ def batch_process_dl1(dict_paths, conf_file, batch_config, logs, workflow_kind="
     return jobids_dl1_processing_stage
 
 
-def r0_to_dl1(input_dir, output_dir, workflow_kind="lstchain", config_file=None, batch_config=None, debug_mode=False,
-              keep_rta_file=False, extra_slurm_options=None):
+def r0_to_dl1(
+    input_dir,
+    output_dir,
+    workflow_kind="lstchain",
+    config_file=None,
+    batch_config=None,
+    debug_mode=False,
+    keep_rta_file=False,
+    extra_slurm_options=None,
+):
     """
     R0 to DL1 MC onsite conversion.
     Organizes files and launches slurm jobs in two slurm arrays.
@@ -142,10 +160,18 @@ def r0_to_dl1(input_dir, output_dir, workflow_kind="lstchain", config_file=None,
     job_logs_dir = output_dir.joinpath("job_logs_r0dl1")
     Path(job_logs_dir).mkdir(exist_ok=True, parents=True)
     log.info(f"DL1 DATA DIR: {output_dir}")
-    jobid2log, jobids_r0_dl1 = submit_dl1_jobs(input_dir, output_dir, base_cmd=base_cmd, file_list=raw_files_list,
-                                               job_type_id=jobtype_id, dl1_files_per_batched_job=dl1_files_per_job,
-                                               job_logs_dir=job_logs_dir, batch_config=batch_config,
-                                               dl1_processing_type="r0_to_dl1", extra_slurm_options=extra_slurm_options)
+    jobid2log, jobids_r0_dl1 = submit_dl1_jobs(
+        input_dir,
+        output_dir,
+        base_cmd=base_cmd,
+        file_list=raw_files_list,
+        job_type_id=jobtype_id,
+        dl1_files_per_batched_job=dl1_files_per_job,
+        job_logs_dir=job_logs_dir,
+        batch_config=batch_config,
+        dl1_processing_type="r0_to_dl1",
+        extra_slurm_options=extra_slurm_options,
+    )
 
     if config_file is not None:
         shutil.copyfile(config_file, job_logs_dir.joinpath(Path(config_file).name))
@@ -153,8 +179,15 @@ def r0_to_dl1(input_dir, output_dir, workflow_kind="lstchain", config_file=None,
     return jobid2log, jobids_r0_dl1
 
 
-def reprocess_dl1(input_dir, output_dir, workflow_kind="lstchain", config_file=None, batch_config=None,
-                  dl1_files_per_job=50, extra_slurm_options=None):
+def reprocess_dl1(
+    input_dir,
+    output_dir,
+    workflow_kind="lstchain",
+    config_file=None,
+    batch_config=None,
+    dl1_files_per_job=50,
+    extra_slurm_options=None,
+):
     """
     Reprocessing of existing dl1 files.
     Organizes files and launches slurm jobs in two slurm arrays.
@@ -210,10 +243,18 @@ def reprocess_dl1(input_dir, output_dir, workflow_kind="lstchain", config_file=N
     job_logs_dir = Path(output_dir).joinpath("job_logs_dl1ab")
     Path(job_logs_dir).mkdir(exist_ok=True)
     log.info(f"DL1ab destination DATA DIR: {output_dir}")
-    jobid2log, jobids_dl1_dl1 = submit_dl1_jobs(input_dir, output_dir, base_cmd=base_cmd, file_list=dl1ab_filelist,
-                                                job_type_id=jobtype_id, dl1_files_per_batched_job=dl1_files_per_job,
-                                                job_logs_dir=job_logs_dir, batch_config=batch_config,
-                                                dl1_processing_type="dl1ab", extra_slurm_options=extra_slurm_options)
+    jobid2log, jobids_dl1_dl1 = submit_dl1_jobs(
+        input_dir,
+        output_dir,
+        base_cmd=base_cmd,
+        file_list=dl1ab_filelist,
+        job_type_id=jobtype_id,
+        dl1_files_per_batched_job=dl1_files_per_job,
+        job_logs_dir=job_logs_dir,
+        batch_config=batch_config,
+        dl1_processing_type="dl1ab",
+        extra_slurm_options=extra_slurm_options,
+    )
 
     if config_file is not None:
         shutil.copyfile(config_file, job_logs_dir.joinpath(Path(config_file).name))
@@ -221,8 +262,19 @@ def reprocess_dl1(input_dir, output_dir, workflow_kind="lstchain", config_file=N
     return jobid2log, jobids_dl1_dl1
 
 
-def submit_dl1_jobs(input_dir, output_dir, base_cmd, file_list, job_type_id, dl1_files_per_batched_job, job_logs_dir,
-                    batch_config, n_jobs_parallel=100, dl1_processing_type="r0_to_dl1", extra_slurm_options=None):
+def submit_dl1_jobs(
+    input_dir,
+    output_dir,
+    base_cmd,
+    file_list,
+    job_type_id,
+    dl1_files_per_batched_job,
+    job_logs_dir,
+    batch_config,
+    n_jobs_parallel=100,
+    dl1_processing_type="r0_to_dl1",
+    extra_slurm_options=None,
+):
     """
     Compose sbatch command and batches it
 
@@ -261,7 +313,8 @@ def submit_dl1_jobs(input_dir, output_dir, base_cmd, file_list, job_type_id, dl1
 
     """
     number_of_sublists = len(file_list) // dl1_files_per_batched_job + int(
-        len(file_list) % dl1_files_per_batched_job > 0)
+        len(file_list) % dl1_files_per_batched_job > 0
+    )
 
     for i in range(number_of_sublists):
         output_file = job_logs_dir.joinpath(f"{dl1_processing_type}_{i}.sublist").resolve().as_posix()
@@ -278,14 +331,16 @@ def submit_dl1_jobs(input_dir, output_dir, base_cmd, file_list, job_type_id, dl1
 
     if extra_slurm_options is not None:
         extra_slurm_default_options.update(extra_slurm_options)
-    sbatch_process_dl1 = SbatchLstMCStage(dl1_processing_type,
-                                          wrap_command=cmd,
-                                          job_name=f"{job_type_id}-{dl1_processing_type}",
-                                          slurm_error=job_logs_dir.joinpath("job_%A_%a.e").as_posix(),
-                                          slurm_output=job_logs_dir.joinpath("job_%A_%a.o").as_posix(),
-                                          slurm_account=batch_config["slurm_account"],
-                                          source_environment=batch_config["source_environment"],
-                                          extra_slurm_options=extra_slurm_default_options)
+    sbatch_process_dl1 = SbatchLstMCStage(
+        dl1_processing_type,
+        wrap_command=cmd,
+        job_name=f"{job_type_id}-{dl1_processing_type}",
+        slurm_error=job_logs_dir.joinpath("job_%A_%a.e").as_posix(),
+        slurm_output=job_logs_dir.joinpath("job_%A_%a.o").as_posix(),
+        slurm_account=batch_config["slurm_account"],
+        source_environment=batch_config["source_environment"],
+        extra_slurm_options=extra_slurm_default_options,
+    )
 
     jobid = sbatch_process_dl1.submit()
     log.debug(f"Submitted batch job {jobid}")

--- a/lstmcpipe/stages/mc_process_dl1.py
+++ b/lstmcpipe/stages/mc_process_dl1.py
@@ -277,7 +277,7 @@ def submit_dl1_jobs(input_dir, output_dir, base_cmd, file_list, job_type_id, dl1
     extra_slurm_default_options = {'partition': 'long', 'array': f"0-{len(sublist_names) - 1}%{n_jobs_parallel}"}
 
     if extra_slurm_options is not None:
-        extra_slurm_default_options |= extra_slurm_options
+        extra_slurm_default_options.update(extra_slurm_options)
     sbatch_process_dl1 = SbatchLstMCStage(dl1_processing_type,
                                           wrap_command=cmd,
                                           job_name=f"{job_type_id}-{dl1_processing_type}",

--- a/lstmcpipe/stages/mc_process_dl1.py
+++ b/lstmcpipe/stages/mc_process_dl1.py
@@ -11,14 +11,7 @@ from ..io.data_management import check_data_path, get_input_filelist
 log = logging.getLogger(__name__)
 
 
-def batch_process_dl1(
-    dict_paths,
-    conf_file,
-    batch_config,
-    logs,
-    workflow_kind="lstchain",
-    new_production=True,
-):
+def batch_process_dl1(dict_paths, conf_file, batch_config, logs, workflow_kind="lstchain", new_production=True):
     """
     Batch the dl1 processing jobs by particle type.
 
@@ -46,68 +39,40 @@ def batch_process_dl1(
     log_process_dl1 = {}
     debug_log = {}
     jobids_dl1_processing_stage = []
-
-    log.info("==== START {} dl1 processing ====".format(workflow_kind))
-
+    log.info(f"==== START {workflow_kind} dl1 processing ====")
     if new_production:
-
         for paths in dict_paths["r0_to_dl1"]:
-
             try:
                 check_data_path(paths["input"], glob="*.simtel.gz")
             except ValueError:
                 debug_log["**EMPTY_R0_DIR**"] = f'{paths["input"]} directory does not contain any simtel.gz file'
-                continue
 
-            job_logs, jobid = r0_to_dl1(
-                paths["input"],
-                paths["output"],
-                config_file=conf_file,
-                batch_config=batch_config,
-                workflow_kind=workflow_kind,
-                extra_slurm_options=paths.get("extra_slurm_options", None),
-            )
+                continue
+            job_logs, jobid = r0_to_dl1(paths["input"], paths["output"], config_file=conf_file,
+                                        batch_config=batch_config, workflow_kind=workflow_kind,
+                                        extra_slurm_options=paths.get("extra_slurm_options", None))
+
             log_process_dl1.update(job_logs)
             jobids_dl1_processing_stage.append(jobid)
             debug_log[jobid] = f'r0_dl1 job from input dir: {paths["input"]}'
-
     else:
-
         for paths in dict_paths["dl1ab"]:
-            job_logs, jobid = reprocess_dl1(
-                paths["input"],
-                paths["output"],
-                config_file=conf_file,
-                batch_config=batch_config,
-                workflow_kind=workflow_kind,
-                extra_slurm_options=paths.get("extra_slurm_options", None),
-            )
+            job_logs, jobid = reprocess_dl1(paths["input"], paths["output"], config_file=conf_file,
+                                            batch_config=batch_config, workflow_kind=workflow_kind,
+                                            extra_slurm_options=paths.get("extra_slurm_options", None))
 
             log_process_dl1.update(job_logs)
             jobids_dl1_processing_stage.append(jobid)
             debug_log[jobid] = f'dl1ab job from input dir: {paths["input"]}'
-
-    # Create a string to be directly passed
     jobids_dl1_processing_stage = ",".join(jobids_dl1_processing_stage)
-
     save_log_to_file(log_process_dl1, logs["log_file"], "r0_to_dl1")
     save_log_to_file(debug_log, logs["debug_file"], workflow_step="r0_to_dl1")
-
-    log.info("==== END {} dl1 processing ====".format(workflow_kind))
-
+    log.info(f"==== END {workflow_kind} dl1 processing ====")
     return jobids_dl1_processing_stage
 
 
-def r0_to_dl1(
-    input_dir,
-    output_dir,
-    workflow_kind="lstchain",
-    config_file=None,
-    batch_config=None,
-    debug_mode=False,
-    keep_rta_file=False,
-    extra_slurm_options=None,
-):
+def r0_to_dl1(input_dir, output_dir, workflow_kind="lstchain", config_file=None, batch_config=None, debug_mode=False,
+              keep_rta_file=False, extra_slurm_options=None):
     """
     R0 to DL1 MC onsite conversion.
     Organizes files and launches slurm jobs in two slurm arrays.
@@ -145,9 +110,7 @@ def r0_to_dl1(
     jobids_r0_dl1
         A list of all the jobs sent for input dir
     """
-
-    log.info("\nStarting R0 to DL1 processing for files in dir : {}".format(input_dir))
-
+    log.info(f'\nStarting R0 to DL1 processing for files in dir : {input_dir}')
     if workflow_kind == "lstchain":
         base_cmd = f"lstmcpipe_lst_core_r0_dl1 -c {config_file} "
         jobtype_id = "LST"
@@ -160,71 +123,38 @@ def r0_to_dl1(
             base_cmd += " --keep_rta_file"
         if debug_mode:
             base_cmd += " --debug_mode"
-
         jobtype_id = "RTA"
     else:
         base_cmd = ''
         jobtype_id = ''
         log.critical("Please, select an allowed workflow kind.")
         exit(-1)
-
     raw_files_list = get_input_filelist(input_dir, glob_pattern="*.simtel.gz")
-
-    if len(raw_files_list) < 50:
-        dl1_files_per_job = 20
-    else:
-        dl1_files_per_job = 50
-
+    dl1_files_per_job = 20 if len(raw_files_list) < 50 else 50
     with open("r0_to_dl1.list", "w+") as newfile:
         for f in raw_files_list:
             newfile.write(f)
             newfile.write("\n")
-
-    log.info("{} raw R0 files".format(len(raw_files_list)))
-
-    # If file exists, means that prod is being re-run
+    log.info(f"{len(raw_files_list)} raw R0 files")
     output_dir = Path(output_dir)
     if output_dir.exists() and any(output_dir.iterdir()):
         shutil.rmtree(output_dir)
-
     job_logs_dir = output_dir.joinpath("job_logs_r0dl1")
     Path(job_logs_dir).mkdir(exist_ok=True, parents=True)
+    log.info(f"DL1 DATA DIR: {output_dir}")
+    jobid2log, jobids_r0_dl1 = submit_dl1_jobs(input_dir, output_dir, base_cmd=base_cmd, file_list=raw_files_list,
+                                               job_type_id=jobtype_id, dl1_files_per_batched_job=dl1_files_per_job,
+                                               job_logs_dir=job_logs_dir, batch_config=batch_config,
+                                               dl1_processing_type="r0_to_dl1", extra_slurm_options=extra_slurm_options)
 
-    log.info("DL1 DATA DIR: {}".format(output_dir))
-
-    jobid2log, jobids_r0_dl1 = submit_dl1_jobs(
-        input_dir,
-        output_dir,
-        base_cmd=base_cmd,
-        file_list=raw_files_list,
-        job_type_id=jobtype_id,
-        dl1_files_per_batched_job=dl1_files_per_job,
-        job_logs_dir=job_logs_dir,
-        batch_config=batch_config,
-        dl1_processing_type="r0_to_dl1",
-        extra_slurm_options=extra_slurm_options,
-    )
-
-    # copy config into working dir
     if config_file is not None:
         shutil.copyfile(config_file, job_logs_dir.joinpath(Path(config_file).name))
-
-    # save file lists into logs
     shutil.move("r0_to_dl1.list", job_logs_dir)
-
-    # return it log dictionary
     return jobid2log, jobids_r0_dl1
 
 
-def reprocess_dl1(
-    input_dir,
-    output_dir,
-    workflow_kind="lstchain",
-    config_file=None,
-    batch_config=None,
-    dl1_files_per_job=50,
-    extra_slurm_options=None,
-):
+def reprocess_dl1(input_dir, output_dir, workflow_kind="lstchain", config_file=None, batch_config=None,
+                  dl1_files_per_job=50, extra_slurm_options=None):
     """
     Reprocessing of existing dl1 files.
     Organizes files and launches slurm jobs in two slurm arrays.
@@ -256,8 +186,7 @@ def reprocess_dl1(
     jobids_dl1_dl1
         A list of all the jobs sent for input dir
     """
-    log.info("Applying DL1ab on DL1 files in {}".format(input_dir))
-
+    log.info(f"Applying DL1ab on DL1 files in {input_dir}")
     if workflow_kind == "lstchain":
         base_cmd = f"lstmcpipe_lst_core_dl1ab -c {config_file} "
         jobtype_id = "LST"
@@ -269,60 +198,31 @@ def reprocess_dl1(
         jobtype_id = ""
         log.critical(f"Unknown workflow {workflow_kind}")
         exit(-1)
-
     check_data_path(input_dir)
     dl1ab_filelist = [file.resolve().as_posix() for file in Path(input_dir).glob("*.h5")]
 
-    log.info("{} DL1 files".format(len(dl1ab_filelist)))
-
+    log.info(f"{len(dl1ab_filelist)} DL1 files")
     with open("dl1ab.list", "w+") as newfile:
         for f in dl1ab_filelist:
             newfile.write(f)
             newfile.write("\n")
-
     Path(output_dir).mkdir(exist_ok=True, parents=True)
     job_logs_dir = Path(output_dir).joinpath("job_logs_dl1ab")
     Path(job_logs_dir).mkdir(exist_ok=True)
+    log.info(f"DL1ab destination DATA DIR: {output_dir}")
+    jobid2log, jobids_dl1_dl1 = submit_dl1_jobs(input_dir, output_dir, base_cmd=base_cmd, file_list=dl1ab_filelist,
+                                                job_type_id=jobtype_id, dl1_files_per_batched_job=dl1_files_per_job,
+                                                job_logs_dir=job_logs_dir, batch_config=batch_config,
+                                                dl1_processing_type="dl1ab", extra_slurm_options=extra_slurm_options)
 
-    log.info("DL1ab destination DATA DIR: {}".format(output_dir))
-
-    jobid2log, jobids_dl1_dl1 = submit_dl1_jobs(
-        input_dir,
-        output_dir,
-        base_cmd=base_cmd,
-        file_list=dl1ab_filelist,
-        job_type_id=jobtype_id,
-        dl1_files_per_batched_job=dl1_files_per_job,
-        job_logs_dir=job_logs_dir,
-        batch_config=batch_config,
-        dl1_processing_type="dl1ab",
-        extra_slurm_options=extra_slurm_options,
-    )
-
-    # copy config into working dir
     if config_file is not None:
         shutil.copyfile(config_file, job_logs_dir.joinpath(Path(config_file).name))
-
-    # save file lists into logs
     shutil.move("dl1ab.list", job_logs_dir)
-
-    # return it log dictionary
     return jobid2log, jobids_dl1_dl1
 
 
-def submit_dl1_jobs(
-    input_dir,
-    output_dir,
-    base_cmd,
-    file_list,
-    job_type_id,
-    dl1_files_per_batched_job,
-    job_logs_dir,
-    batch_config,
-    n_jobs_parallel=100,
-    dl1_processing_type="r0_to_dl1",
-    extra_slurm_options=None,
-):
+def submit_dl1_jobs(input_dir, output_dir, base_cmd, file_list, job_type_id, dl1_files_per_batched_job, job_logs_dir,
+                    batch_config, n_jobs_parallel=100, dl1_processing_type="r0_to_dl1", extra_slurm_options=None):
     """
     Compose sbatch command and batches it
 
@@ -360,46 +260,34 @@ def submit_dl1_jobs(
     jobid: str
 
     """
-    jobid2log = {}
-
     number_of_sublists = len(file_list) // dl1_files_per_batched_job + int(
-        len(file_list) % dl1_files_per_batched_job > 0
-    )
+        len(file_list) % dl1_files_per_batched_job > 0)
 
     for i in range(number_of_sublists):
-        output_file = job_logs_dir.joinpath("{}_{}.sublist".format(dl1_processing_type, i)).resolve().as_posix()
+        output_file = job_logs_dir.joinpath(f"{dl1_processing_type}_{i}.sublist").resolve().as_posix()
+
         with open(output_file, "w+") as out:
-            for line in file_list[i * dl1_files_per_batched_job : dl1_files_per_batched_job * (i + 1)]:  # noqa
+            for line in file_list[i * dl1_files_per_batched_job:dl1_files_per_batched_job * (i + 1)]:
                 out.write(line)
                 out.write("\n")
-
     log.info(f"{number_of_sublists} files generated for list of files at {input_dir}")
 
-    sublist_names = [f.as_posix() for f in Path(job_logs_dir).glob("*.sublist")]  # Number of sublists ??
-
-    # start 1 jobarray with all files included. The job selects its file based on its task id
+    sublist_names = [f.as_posix() for f in Path(job_logs_dir).glob("*.sublist")]
     cmd = f'{base_cmd} -f {" ".join(sublist_names)} --output_dir {output_dir}'
+    extra_slurm_default_options = {'partition': 'long', 'array': f"0-{len(sublist_names) - 1}%{n_jobs_parallel}"}
 
-    extra_slurm_default_options = {'partition': 'long',
-                                   'array': f"0-{len(sublist_names) - 1}%{n_jobs_parallel}",
-                                   }
     if extra_slurm_options is not None:
-        extra_slurm_default_options.update(extra_slurm_options)
-
-    sbatch_process_dl1 = SbatchLstMCStage(
-        dl1_processing_type,
-        wrap_command=cmd,
-        job_name=f"{job_type_id}-{dl1_processing_type}",
-        slurm_error=job_logs_dir.joinpath("job_%A_%a.e").as_posix(),
-        slurm_output=job_logs_dir.joinpath("job_%A_%a.o").as_posix(),
-        slurm_account=batch_config["slurm_account"],
-        source_environment=batch_config["source_environment"],
-        extra_slurm_options=extra_slurm_default_options,
-    )
+        extra_slurm_default_options |= extra_slurm_options
+    sbatch_process_dl1 = SbatchLstMCStage(dl1_processing_type,
+                                          wrap_command=cmd,
+                                          job_name=f"{job_type_id}-{dl1_processing_type}",
+                                          slurm_error=job_logs_dir.joinpath("job_%A_%a.e").as_posix(),
+                                          slurm_output=job_logs_dir.joinpath("job_%A_%a.o").as_posix(),
+                                          slurm_account=batch_config["slurm_account"],
+                                          source_environment=batch_config["source_environment"],
+                                          extra_slurm_options=extra_slurm_default_options)
 
     jobid = sbatch_process_dl1.submit()
     log.debug(f"Submitted batch job {jobid}")
-
-    jobid2log.update({jobid: sbatch_process_dl1.slurm_command})
-
+    jobid2log = {jobid: sbatch_process_dl1.slurm_command}
     return jobid2log, jobid

--- a/lstmcpipe/stages/mc_train.py
+++ b/lstmcpipe/stages/mc_train.py
@@ -55,7 +55,7 @@ def batch_train_pipe(dict_paths, jobids_from_merge, config_file, batch_config, l
             config_file=config_file,
             batch_configuration=batch_config,
             wait_jobs_dl1=jobids_from_merge,
-            slurm_options=paths.get("extra_slurm_options", None),
+            extra_slurm_options=paths.get("extra_slurm_options", None),
         )
 
         log_train.update(job_logs)
@@ -70,7 +70,7 @@ def batch_train_pipe(dict_paths, jobids_from_merge, config_file, batch_config, l
     save_log_to_file(log_train, logs["log_file"], workflow_step="train_pipe")
     save_log_to_file(debug_train, logs["debug_file"], workflow_step="train_pipe")
 
-    log.info("==== END {} ====".format("batch mc_train_workflow"))
+    log.info("==== END batch mc_train_workflow ====")
 
     return jobid_for_dl1_to_dl2
 

--- a/lstmcpipe/stages/mc_train.py
+++ b/lstmcpipe/stages/mc_train.py
@@ -23,7 +23,7 @@ def batch_train_pipe(dict_paths, jobids_from_merge, config_file, batch_config, l
         Path to a configuration file. If none is given, a standard configuration is applied
     jobids_from_merge : str
         string containing the jobids (***ONLY from proton and gamma-diffuse***) from the jobs batched in the
-         merge_and_copy_dl1 stage, to be passed to the train_pipe function (as a slurm dependency)
+         merge_and_copy_dl1 stage, to be passed to the train_pipe function (as a slurm dependency_type)
     batch_config : dict
         Dictionary containing the (full) source_environment and the slurm_account strings to be passed to
         the `train_pipe` function.
@@ -33,7 +33,7 @@ def batch_train_pipe(dict_paths, jobids_from_merge, config_file, batch_config, l
     Returns
     -------
     jobid_4_dl1_to_dl2 : str
-        string containing the jobid to be passed to the next stage of the workflow (as a slurm dependency).
+        string containing the jobid to be passed to the next stage of the workflow (as a slurm dependency_type).
         For the next stage, however, it will be needed TRAIN + MERGED jobs
     """
     log_train = {}
@@ -55,7 +55,7 @@ def batch_train_pipe(dict_paths, jobids_from_merge, config_file, batch_config, l
             config_file=config_file,
             batch_configuration=batch_config,
             wait_jobs_dl1=jobids_from_merge,
-            slurm_options=paths.get("slurm_options", None),
+            slurm_options=paths.get("extra_slurm_options", None),
         )
 
         log_train.update(job_logs)
@@ -121,7 +121,7 @@ def batch_plot_rf_features(
             wrap_command=cmd,
             slurm_error=Path(models_dir).joinpath("job_plot_rf_feat_importance.e").resolve().as_posix(),
             slurm_output=Path(models_dir).joinpath(models_dir, "job_plot_rf_feat_importance.o").resolve().as_posix(),
-            slurm_deps=train_jobid,
+            slurm_dependencies=train_jobid,
             slurm_account=batch_configuration["slurm_account"],
             source_environment=batch_configuration["source_environment"],
             backend="export MPLBACKEND=Agg;",
@@ -151,7 +151,7 @@ def train_pipe(
     config_file=None,
     batch_configuration='',
     wait_jobs_dl1=None,
-    slurm_options=None,
+    extra_slurm_options=None,
 ):
     """
     Train RF from MC DL1 data (onsite LaPalma cluster)
@@ -173,7 +173,7 @@ def train_pipe(
     wait_jobs_dl1 : str
         A string (of chained job_ids separated by ',' and without spaces between each element), containing
         all the job_ids of the merging stage
-    slurm_options: str
+    extra_slurm_options: dict
         Extra slurm options to be passed to the sbatch command
 
     Returns
@@ -200,8 +200,8 @@ def train_pipe(
         wrap_command=cmd,
         slurm_error=Path(models_dir).joinpath("train_job.e").resolve().as_posix(),
         slurm_output=Path(models_dir).joinpath("train_job.o").resolve().as_posix(),
-        slurm_deps=wait_jobs_dl1,
-        slurm_options=slurm_options,
+        slurm_dependencies=wait_jobs_dl1,
+        extra_slurm_options=extra_slurm_options,
         slurm_account=batch_configuration["slurm_account"],
         source_environment=batch_configuration["source_environment"],
     )

--- a/lstmcpipe/stages/mc_train.py
+++ b/lstmcpipe/stages/mc_train.py
@@ -23,7 +23,7 @@ def batch_train_pipe(dict_paths, jobids_from_merge, config_file, batch_config, l
         Path to a configuration file. If none is given, a standard configuration is applied
     jobids_from_merge : str
         string containing the jobids (***ONLY from proton and gamma-diffuse***) from the jobs batched in the
-         merge_and_copy_dl1 stage, to be passed to the train_pipe function (as a slurm dependency_type)
+         merge_and_copy_dl1 stage, to be passed to the train_pipe function (as a slurm dependency)
     batch_config : dict
         Dictionary containing the (full) source_environment and the slurm_account strings to be passed to
         the `train_pipe` function.
@@ -33,7 +33,7 @@ def batch_train_pipe(dict_paths, jobids_from_merge, config_file, batch_config, l
     Returns
     -------
     jobid_4_dl1_to_dl2 : str
-        string containing the jobid to be passed to the next stage of the workflow (as a slurm dependency_type).
+        string containing the jobid to be passed to the next stage of the workflow (as a slurm dependency).
         For the next stage, however, it will be needed TRAIN + MERGED jobs
     """
     log_train = {}

--- a/lstmcpipe/stages/mc_train_test_splitting.py
+++ b/lstmcpipe/stages/mc_train_test_splitting.py
@@ -42,7 +42,7 @@ def batch_train_test_splitting(
             paths["output"],
             wait_jobid_r0_dl1=jobids_from_r0dl1,
             batch_configuration=batch_config,
-            slurm_options=paths.get("slurm_options", None),
+            extra_slurm_options=paths.get("extra_slurm_options", None),
         )
 
         log_splitting.update(job_logs)
@@ -64,7 +64,7 @@ def train_test_split(
     output_dirs,
     batch_configuration,
     wait_jobid_r0_dl1=None,
-    slurm_options=None,
+    extra_slurm_options=None,
 ):
     """
 
@@ -74,7 +74,7 @@ def train_test_split(
     output_dirs: dict
     batch_configuration: dict
     wait_jobid_r0_dl1: str
-    slurm_options: str
+    extra_slurm_options: dict
         Extra slurm options to be passed to the sbatch command
 
     Returns
@@ -112,8 +112,8 @@ def train_test_split(
         wrap_command=cmd,
         slurm_error=Path(input_dir).joinpath(input_dir, "split_tt_%j.e"),
         slurm_output=Path(input_dir).joinpath(input_dir, "split_tt_%j.o"),
-        slurm_deps=wait_jobid_r0_dl1,
-        slurm_options=slurm_options,
+        slurm_dependencies=wait_jobid_r0_dl1,
+        extra_slurm_options=extra_slurm_options,
         slurm_account=batch_configuration["slurm_account"],
         source_environment=batch_configuration["source_environment"],
     )

--- a/lstmcpipe/tests/test_utils.py
+++ b/lstmcpipe/tests/test_utils.py
@@ -73,17 +73,18 @@ def test_sbatch_lst_mc_stage():
 
     sbatch = SbatchLstMCStage(stage="r0_to_dl1", wrap_command="command to be batched")
     assert (
-        sbatch.slurm_command == 'sbatch --parsable --job-name=r0_dl1 --partition=long --array=0-0%100  '
+        sbatch.slurm_command == 'sbatch --parsable --partition=long --job-name=r0_dl1 --array=0-0%100  '
         '--error=./slurm-%j.e --output=./slurm-%j.o   --wrap="command to be batched"'
     )
 
-    sbatch.slurm_options = "-A lstrta -p xxl --mem 160G --cpus-per-task=32"
+    sbatch.set_slurm_options(sbatch.stage, {'account':'lstrta', 'partition': 'xxl', 'mem': '160G', 'cpus-per-task': 32})
     assert (
-        sbatch.slurm_command == 'sbatch --parsable --job-name=r0_dl1 -A lstrta -p xxl --mem 160G --cpus-per-task=32 '
-        '--error=./slurm-%j.e --output=./slurm-%j.o   --wrap="command to be batched"'
+        sbatch.slurm_command == 'sbatch --parsable --partition=xxl --job-name=r0_dl1 --array=0-0%100 '
+                                '--error=./slurm-%j.e --output=./slurm-%j.o --account=lstrta --mem=160G '
+                                '--cpus-per-task=32   --wrap="command to be batched" '
     )
 
-    sbatch.slurm_options = None
+    sbatch.set_slurm_options = (sbatch.stage, None)
     sbatch.set_slurm_dependencies("123,243,345,456")
     assert sbatch.slurm_dependencies == "--dependency=afterok:123,243,345,456"
 

--- a/lstmcpipe/tests/test_utils.py
+++ b/lstmcpipe/tests/test_utils.py
@@ -73,8 +73,8 @@ def test_sbatch_lst_mc_stage():
 
     sbatch = SbatchLstMCStage(stage="r0_to_dl1", wrap_command="command to be batched")
     assert (
-        sbatch.slurm_command == 'sbatch --parsable --partition=long --job-name=r0_dl1 --array=0-0%100  '
-        '--error=./slurm-%j.e --output=./slurm-%j.o   --wrap="command to be batched"'
+        sbatch.slurm_command == 'sbatch --parsable --partition=long --job-name=r0_dl1 --array=0-0%100 '
+                                '--error=./slurm-%j.e --output=./slurm-%j.o   --wrap="command to be batched" '
     )
 
     sbatch.set_slurm_options(sbatch.stage, {'account':'lstrta', 'partition': 'xxl', 'mem': '160G', 'cpus-per-task': 32})

--- a/lstmcpipe/tests/test_utils.py
+++ b/lstmcpipe/tests/test_utils.py
@@ -84,7 +84,7 @@ def test_sbatch_lst_mc_stage():
     )
 
     sbatch.slurm_options = None
-    sbatch.check_slurm_dependencies("123,243,345,456")
+    sbatch.set_slurm_dependencies("123,243,345,456")
     assert sbatch.slurm_dependencies == "--dependency=afterok:123,243,345,456"
 
     sbatch.compose_wrap_command(
@@ -96,13 +96,13 @@ def test_sbatch_lst_mc_stage():
 
     with pytest.raises(ValueError):
         sbatch.submit()  # slurm not installed
-        sbatch.stage_default_options("invented_stage")
-        sbatch.check_slurm_dependencies(slurm_deps="123,,234")
+        sbatch.set_stage_default_options("invented_stage")
+        sbatch.set_slurm_dependencies(slurm_deps="123,,234")
 
     stages = sbatch._valid_stages
     for stage in stages:
-        sbatch.stage_default_options(stage)
-        assert "--job-name=" in sbatch.job_name
+        sbatch.set_stage_default_options(stage)
+        assert "--job-name=" in sbatch.slurm_command
         assert "--partition=" in sbatch.slurm_command
 
 

--- a/lstmcpipe/tests/test_utils.py
+++ b/lstmcpipe/tests/test_utils.py
@@ -81,7 +81,7 @@ def test_sbatch_lst_mc_stage():
     assert (
         sbatch.slurm_command == 'sbatch --parsable --partition=xxl --job-name=r0_dl1 --array=0-0%100 '
                                 '--error=./slurm-%j.e --output=./slurm-%j.o --account=lstrta --mem=160G '
-                                '--cpus-per-task=32   --wrap="command to be batched" '
+                                '--cpus-per-task=32   --wrap="command to be batched"'
     )
 
     sbatch.set_slurm_options = (sbatch.stage, None)

--- a/lstmcpipe/tests/test_utils.py
+++ b/lstmcpipe/tests/test_utils.py
@@ -97,7 +97,7 @@ def test_sbatch_lst_mc_stage():
 
     with pytest.raises(ValueError):
         sbatch.submit()  # slurm not installed
-        sbatch.set_stage_default_options("invented_stage")
+        sbatch.stage_default_options("dummy_stage")
         sbatch.set_slurm_dependencies(slurm_deps="123,,234")
 
     stages = sbatch._valid_stages

--- a/lstmcpipe/tests/test_utils.py
+++ b/lstmcpipe/tests/test_utils.py
@@ -74,19 +74,19 @@ def test_sbatch_lst_mc_stage():
     sbatch = SbatchLstMCStage(stage="r0_to_dl1", wrap_command="command to be batched")
     assert (
         sbatch.slurm_command == 'sbatch --parsable --partition=long --job-name=r0_dl1 --array=0-0%100 '
-                                '--error=./slurm-%j.e --output=./slurm-%j.o   --wrap="command to be batched"'
+                                '--error=./slurm-%j.e --output=./slurm-%j.o  --wrap="command to be batched"'
     )
 
-    sbatch.set_slurm_options(sbatch.stage, {'account':'lstrta', 'partition': 'xxl', 'mem': '160G', 'cpus-per-task': 32})
+    sbatch.extra_slurm_options = {'account': 'lstrta', 'partition': 'xxl', 'mem': '160G', 'cpus-per-task': 32}
     assert (
         sbatch.slurm_command == 'sbatch --parsable --partition=xxl --job-name=r0_dl1 --array=0-0%100 '
                                 '--error=./slurm-%j.e --output=./slurm-%j.o --account=lstrta --mem=160G '
-                                '--cpus-per-task=32   --wrap="command to be batched"'
+                                '--cpus-per-task=32  --wrap="command to be batched"'
     )
 
-    sbatch.set_slurm_options = (sbatch.stage, None)
-    sbatch.set_slurm_dependencies("123,243,345,456")
-    assert sbatch.slurm_dependencies == "--dependency=afterok:123,243,345,456"
+    sbatch.extra_slurm_options = None
+    sbatch.slurm_dependencies = "123,243,345,456"
+    assert sbatch._construct_slurm_dependencies() == "--dependency=afterok:123,243,345,456"
 
     sbatch.compose_wrap_command(
         wrap_command="python args",
@@ -102,7 +102,6 @@ def test_sbatch_lst_mc_stage():
 
     stages = sbatch._valid_stages
     for stage in stages:
-        sbatch.set_stage_default_options(stage)
         assert "--job-name=" in sbatch.slurm_command
         assert "--partition=" in sbatch.slurm_command
 

--- a/lstmcpipe/tests/test_utils.py
+++ b/lstmcpipe/tests/test_utils.py
@@ -74,7 +74,7 @@ def test_sbatch_lst_mc_stage():
     sbatch = SbatchLstMCStage(stage="r0_to_dl1", wrap_command="command to be batched")
     assert (
         sbatch.slurm_command == 'sbatch --parsable --partition=long --job-name=r0_dl1 --array=0-0%100 '
-                                '--error=./slurm-%j.e --output=./slurm-%j.o   --wrap="command to be batched" '
+                                '--error=./slurm-%j.e --output=./slurm-%j.o   --wrap="command to be batched"'
     )
 
     sbatch.set_slurm_options(sbatch.stage, {'account':'lstrta', 'partition': 'xxl', 'mem': '160G', 'cpus-per-task': 32})

--- a/lstmcpipe/utils.py
+++ b/lstmcpipe/utils.py
@@ -319,7 +319,7 @@ class SbatchLstMCStage:
             "dl2_sens_plot": getattr(self, "set_dl2_sens_plot_default_options"),
         }
 
-        default_options.update(stage_options_dict[self.stage])
+        default_options.update(stage_options_dict[stage])
         return default_options
 
     @property
@@ -345,7 +345,8 @@ class SbatchLstMCStage:
         if self.slurm_output is not None:
             self.slurm_options['output'] = self.slurm_output
 
-        self.slurm_options.update(slurm_options)
+        if slurm_options is not None:
+            self.slurm_options.update(slurm_options)
 
     @property
     def r0_dl1_options(self):

--- a/lstmcpipe/utils.py
+++ b/lstmcpipe/utils.py
@@ -319,7 +319,6 @@ class SbatchLstMCStage:
         default_options.update(stage_options_dict[stage])
         return default_options
 
-    @property
     def submit(self):
         if self.wrap_cmd is not None and self.wrap_cmd != "":
             return run_command(self.slurm_command)

--- a/lstmcpipe/utils.py
+++ b/lstmcpipe/utils.py
@@ -244,7 +244,7 @@ class SbatchLstMCStage:
         self.job_name = f"--job-name={job_name}" if job_name is not None else ""
         self.slurm_account = f"--account={slurm_account}" if slurm_account is not None else ""
 
-        self.slurm_partition = f"--partition={slurm_account}" if slurm_partition is not None else "--partition=short"
+        self.slurm_partition = f"--partition={slurm_partition}" if slurm_partition is not None else "--partition=short"
         self.slurm_options = f"{slurm_options}" if slurm_options is not None else None
 
         self.slurm_dependencies = None
@@ -358,6 +358,7 @@ class SbatchLstMCStage:
 
     def set_dl1_dl2_default_options(self):
         self.job_name = "--job-name=dl1_2"
+        self.slurm_partition = "--partition=short"
         self.slurm_options = "--partition=short --mem=32G"
 
     def set_dl2_irfs_default_options(self):

--- a/lstmcpipe/utils.py
+++ b/lstmcpipe/utils.py
@@ -321,7 +321,8 @@ class SbatchLstMCStage:
 
     def submit(self):
         if self.wrap_cmd is not None and self.wrap_cmd != "":
-            return run_command(self.slurm_command)
+            jobid = run_command(self.slurm_command)
+            return jobid
         else:
             raise ValueError(
                 "You must first define the command to be batched: " "SbatchLstMCStage().wrap_command('COMMAND')"

--- a/lstmcpipe/utils.py
+++ b/lstmcpipe/utils.py
@@ -239,53 +239,17 @@ class SbatchLstMCStage:
         self.wrap_cmd = wrap_command
 
         self.slurm_output = "./slurm-%j.o" if slurm_output is None else slurm_output
-        self.slurm_error =  "./slurm-%j.e" if slurm_error is None else slurm_error
+        self.slurm_error = "./slurm-%j.e" if slurm_error is None else slurm_error
         self.job_name = job_name
         self.slurm_account = slurm_account
         self.slurm_dependencies = slurm_dependencies
         self.extra_slurm_options = extra_slurm_options
-
-        # self.set_slurm_dependencies(slurm_dependencies)
 
         self.compose_wrap_command(wrap_command, source_environment, backend)
 
     def __str__(self):
         # return full string
         return self.slurm_command
-
-    # @property
-    # def slurm_account(self):
-    #     return self._slurm_account
-    #
-    # @slurm_account.setter
-    # def job_name(self, slurm_account):
-    #     self._slurm_account = f"--account={slurm_account}"
-    #
-    # @property
-    # def job_name(self):
-    #     return self._job_name
-    #
-    # @job_name.setter
-    # def job_name(self, job_name):
-    #     self._job_name = f"--job-name={job_name}"
-    #
-    # @property
-    # def slurm_error(self):
-    #     return self._slurm_error
-    #
-    # @slurm_error.setter
-    # def slurm_error(self, slurm_error):
-    #     error = "./slurm-%j.e" if slurm_error is None else slurm_error
-    #     self._slurm_error = f"--error={error}"
-    #
-    # @property
-    # def slurm_output(self):
-    #     return self._slurm_output
-    #
-    # @slurm_output.setter
-    # def slurm_output(self, slurm_output):
-    #     output = "./slurm-%j.o" if slurm_output is None else slurm_output
-    #     self._slurm_output = f"--output={output}"
 
     @property
     def _valid_stages(self):
@@ -319,10 +283,8 @@ class SbatchLstMCStage:
                 slurm_options_string += f"--job-name={value} "
             elif key == "dependencies":
                 slurm_options_string += f"{self._construct_slurm_dependencies()} "
-            else:
-                if value is not None or value != "":
-                    slurm_options_string += f"--{key}={value} "
-
+            elif value is not None or value != "":
+                slurm_options_string += f"--{key}={value} "
         return f"{self.base_slurm_command} {slurm_options_string} {self.wrap_cmd}"
 
     def _construct_slurm_dependencies(self):

--- a/lstmcpipe/utils.py
+++ b/lstmcpipe/utils.py
@@ -237,6 +237,7 @@ class SbatchLstMCStage:
         backend="",
     ):
         self.base_slurm_command = "sbatch --parsable"
+        self.stage_default_options(stage)
 
         self.slurm_output = f"--output={slurm_output}" if slurm_output is not None else "--output=./slurm-%j.o"
         self.slurm_error = f"--error={slurm_error}" if slurm_error is not None else "--error=./slurm-%j.e"
@@ -246,7 +247,6 @@ class SbatchLstMCStage:
         self.slurm_partition = f"--partition={slurm_account}" if slurm_partition is not None else "--partition=short"
         self.slurm_options = f"{slurm_options}" if slurm_options is not None else None
 
-        self.stage_default_options(stage)
         self.slurm_dependencies = None
         self.check_slurm_dependencies(slurm_deps)
         self.wrap_cmd = wrap_command

--- a/lstmcpipe/utils.py
+++ b/lstmcpipe/utils.py
@@ -241,13 +241,9 @@ class SbatchLstMCStage:
 
         self.slurm_output = "./slurm-%j.o" if slurm_output is None else slurm_output
         self.slurm_error = "./slurm-%j.e" if slurm_error is None else slurm_error
-        # self.slurm_output =  if slurm_output is not None else "--output=./slurm-%j.o"
-        # self.slurm_error = f"--error={slurm_error}" if slurm_error is not None else "--error=./slurm-%j.e"
-        # self.job_name = f"--job-name={job_name}" if job_name is not None else ""
         self.job_name = job_name
         self.slurm_account = slurm_account
-        self.slurm_options = slurm_options
-
+        self._slurm_options = None
         self.set_slurm_options(stage, slurm_options)
         self.set_slurm_dependencies(slurm_deps)
 
@@ -284,8 +280,8 @@ class SbatchLstMCStage:
     @property
     def slurm_command(self):
         options = ""
-        if self.slurm_options is not None:
-            for opt_key, opt_value in self.slurm_options.items():
+        if self._slurm_options is not None:
+            for opt_key, opt_value in self._slurm_options.items():
                 options += f"--{opt_key}={opt_value} "
         return (
             f"{self.base_slurm_command} {options} {self.slurm_dependencies} {self.wrap_cmd}"
@@ -331,22 +327,28 @@ class SbatchLstMCStage:
                 "You must first define the command to be batched: " "SbatchLstMCStage().wrap_command('COMMAND')"
             )
 
+    @property
+    def slurm_options(self):
+        return self._slurm_options
+
     def set_slurm_options(self, stage, slurm_options):
-        # set all the slurm options with the following priority order: default, batch, slurm_options
-        self.slurm_options = {}
-        self.slurm_options.update(self.stage_default_options(stage))
+        # set all the slurm options with the following priority order: default, batch, _slurm_options
+        self._slurm_options = {}
+        self._slurm_options.update(self.stage_default_options(stage))
 
         if self.job_name is not None:
-            self.slurm_options['job-name'] = self.job_name
+            self._slurm_options['job-name'] = self.job_name
         if self.slurm_account is not None:
-            self.slurm_options['account'] = self.slurm_account
+            self._slurm_options['account'] = self.slurm_account
         if self.slurm_error is not None:
-            self.slurm_options['error'] = self.slurm_error
+            self._slurm_options['error'] = self.slurm_error
         if self.slurm_output is not None:
-            self.slurm_options['output'] = self.slurm_output
+            self._slurm_options['output'] = self.slurm_output
 
         if slurm_options is not None:
-            self.slurm_options.update(slurm_options)
+            self._slurm_options.update(slurm_options)
+
+
 
     @property
     def r0_dl1_options(self):


### PR DESCRIPTION
The main changes concerns the slurm options in `SbatchLstMCStage` and config files.
These options are now handled as dictionnaries,  allowing more flexibility and clarity.
The "general" options (account, error or output files...) are still set on their own but can be overwritten by specific slurm options in some stages.
Default options are easily overwritten too, but the user does not need to specify the full extent of them as it was the case before.


- [x] fix slurm_options
- [x] modify paths_configs generation accordingly