### PR TITLE
20220913 crab theta23 tuned

### DIFF
--- a/production_configs/20220913_crab_theta23_tuned/README.md
+++ b/production_configs/20220913_crab_theta23_tuned/README.md
@@ -1,0 +1,14 @@
+#  20220913_crab_theta23_tuned
+
+Following production `20220902_crab_test_nodes` that had no tuning.
+
+
+Processing of nodes node_theta_23.630_az_100.758 and node_theta_23.630_az_259.265_ only for:
+- dl1ab
+    -  with tuned config from [crab tuned prod](https://github.com/cta-observatory/lstmcpipe/blob/master/production_configs/20220518_v0.9.6_allsky_dec2276_tuned/lstchain_config_dec_2276_tuned.json)
+- merge
+- dl1_to_dl2
+    - with trained RF from crab tuned prod: `/fefs/aswg/data/models/AllSky/20220518_allsky_dec2276_tuned/dec_2276`
+- dl2_to_irfs
+
+See https://github.com/cta-observatory/lst-sim-config/issues/49#issuecomment-1235392024

--- a/production_configs/20220913_crab_theta23_tuned/lstchain_config_dec_2276_tuned.json
+++ b/production_configs/20220913_crab_theta23_tuned/lstchain_config_dec_2276_tuned.json
@@ -1,0 +1,316 @@
+{
+    "source_config": {
+        "EventSource": {
+            "allowed_tels": [
+                1
+            ],
+            "max_events": null
+        },
+        "LSTEventSource": {
+            "default_trigger_type": "ucts",
+            "allowed_tels": [
+                1
+            ],
+            "min_flatfield_adc": 3000,
+            "min_flatfield_pixel_fraction": 0.8,
+            "calibrate_flatfields_and_pedestals": false,
+            "EventTimeCalculator": {
+                "dragon_reference_counter": null,
+                "dragon_reference_time": null
+            },
+            "PointingSource": {
+                "drive_report_path": null
+            },
+            "LSTR0Corrections": {
+                "calib_scale_high_gain": 1.088,
+                "calib_scale_low_gain": 1.004,
+                "drs4_pedestal_path": null,
+                "calibration_path": null,
+                "drs4_time_calibration_path": null
+            }
+        }
+    },
+    "events_filters": {
+        "intensity": [
+            0,
+            Infinity
+        ],
+        "width": [
+            0,
+            Infinity
+        ],
+        "length": [
+            0,
+            Infinity
+        ],
+        "wl": [
+            0,
+            Infinity
+        ],
+        "r": [
+            0,
+            Infinity
+        ],
+        "leakage_intensity_width_2": [
+            0,
+            Infinity
+        ]
+    },
+    "n_training_events": {
+        "gamma_regressors": 1.0,
+        "gamma_tmp_regressors": 0.8,
+        "gamma_classifier": 0.2,
+        "proton_classifier": 1.0
+    },
+    "tailcut": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "sigma": 2.5,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "dynamic_cleaning": {
+        "apply": true,
+        "threshold": 267,
+        "fraction_cleaning_intensity": 0.03
+    },
+    "random_forest_energy_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "random_forest_particle_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "energy_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2",
+        "alt_tel",
+        "az_tel"
+    ],
+    "disp_method": "disp_norm_sign",
+    "disp_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2",
+        "alt_tel",
+        "az_tel"
+    ],
+    "disp_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2",
+        "alt_tel",
+        "az_tel"
+    ],
+    "particle_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2",
+        "log_reco_energy",
+        "reco_disp_norm",
+        "reco_disp_sign",
+        "alt_tel",
+        "az_tel"
+    ],
+    "allowed_tels": [
+        1,
+        2,
+        3,
+        4
+    ],
+    "image_modifier": {
+    "increase_nsb": true,
+    "extra_noise_in_dim_pixels": 1.27,
+    "extra_bias_in_dim_pixels": 0.665,
+    "transition_charge": 8,
+    "extra_noise_in_bright_pixels": 2.08,
+    "increase_psf": false,
+    "smeared_light_fraction": 0 
+    },
+
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+        "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "timestamps_pointing": "ucts",
+    "train_gamma_src_r_deg": [
+        0,
+        Infinity
+    ],
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+    "volume_reducer": {
+        "algorithm": null,
+        "parameters": {}
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+    "LSTCalibrationCalculator": {
+        "systematic_correction_path": null,
+        "squared_excess_noise_factor": 1.222,
+        "flatfield_product": "FlasherFlatFieldCalculator",
+        "pedestal_product": "PedestalIntegrator",
+        "PedestalIntegrator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_median_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_product": "FixedWindowSum",
+            "FixedWindowSum": {
+                "window_shift": 6,
+                "window_width": 12,
+                "peak_index": 18,
+                "apply_integration_correction": false
+            }
+        },
+        "FlasherFlatFieldCalculator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_product": "LocalPeakWindowSum",
+            "charge_median_cut_outliers": [
+                -0.5,
+                0.5
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "time_cut_outliers": [
+                2,
+                38
+            ],
+            "LocalPeakWindowSum": {
+                "window_shift": 5,
+                "window_width": 12,
+                "apply_integration_correction": false
+            }
+        }
+    },
+    "waveform_nsb_tuning": {
+        "nsb_tuning": false,
+        "nsb_tuning_ratio": 0.52,
+        "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    }
+}

--- a/production_configs/20220913_crab_theta23_tuned/lstmcpipe_config_20220913_crab_theta23_tuned.yml
+++ b/production_configs/20220913_crab_theta23_tuned/lstmcpipe_config_20220913_crab_theta23_tuned.yml
@@ -1,0 +1,58 @@
+# lstmcpipe config - 2022-09-13
+
+workflow_kind: lstchain
+
+# prod_id ex: local_no_n_islands. Default; v00 (if key left empty or None)
+prod_id: 20220913_crab_theta23_tuned
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.9.6
+
+slurm_config:
+# dpps is the default account for lstanalyzer - other users should use aswg
+  user_account: dpps
+
+
+lstmcpipe_version: 0.8.1
+prod_type: PathConfigAllSkyFullDL1ab
+stages_to_run:
+- dl1ab
+- merge_dl1
+- dl1_to_dl2
+- dl2_to_irfs
+stages:
+  dl1ab:
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20220902_crab_test_nodes/TestingDataset/node_theta_23.630_az_100.758_
+    output: /fefs/aswg/data/mc/DL1/AllSky/20220913_crab_theta23_tuned/TestingDataset/node_theta_23.630_az_100.758_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20220902_crab_test_nodes/TestingDataset/node_theta_23.630_az_259.265_
+    output: /fefs/aswg/data/mc/DL1/AllSky/20220913_crab_theta23_tuned/TestingDataset/node_theta_23.630_az_259.265_
+  merge_dl1:
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20220913_crab_theta23_tuned/TestingDataset/node_theta_23.630_az_100.758_
+    output: /fefs/aswg/data/mc/DL1/AllSky/20220913_crab_theta23_tuned/TestingDataset/dl1_crab_theta23_node_theta_23.630_az_100.758__merged.h5
+    options: --no-image
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20220913_crab_theta23_tuned/TestingDataset/node_theta_23.630_az_259.265_
+    output: /fefs/aswg/data/mc/DL1/AllSky/20220913_crab_theta23_tuned/TestingDataset/dl1_crab_theta23_node_theta_23.630_az_259.265__merged.h5
+    options: --no-image
+  dl1_to_dl2:
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20220913_crab_theta23_tuned/TestingDataset/dl1_crab_theta23_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20220518_allsky_dec2276_tuned/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20220913_crab_theta23_tuned/TestingDataset/dec_2276/node_theta_23.630_az_100.758_
+    slurm_options: --mem=80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20220913_crab_theta23_tuned/TestingDataset/dl1_crab_theta23_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20220518_allsky_dec2276_tuned/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20220913_crab_theta23_tuned/TestingDataset/dec_2276/node_theta_23.630_az_259.265_
+    slurm_options: --mem=80GB
+  dl2_to_irfs:
+  - input:
+      gamma_file: /fefs/aswg/data/mc/DL2/AllSky/20220913_crab_theta23_tuned/TestingDataset/dec_2276/node_theta_23.630_az_100.758_/dl2_20220913_crab_theta23_tuned_node_theta_23.630_az_100.758__merged.h5
+      proton_file:
+      electron_file:
+    output: /fefs/aswg/data/mc/IRF/AllSky/20220913_crab_theta23_tuned/TestingDataset/dec_2276/node_theta_23.630_az_100.758_/irf_20220913_crab_theta23_tuned_node_theta_23.630_az_100.758_.fits.gz
+    options: --point-like
+  - input:
+      gamma_file: /fefs/aswg/data/mc/DL2/AllSky/20220913_crab_theta23_tuned/TestingDataset/dec_2276/node_theta_23.630_az_259.265_/dl2_20220913_crab_theta23_tuned_node_theta_23.630_az_259.265__merged.h5
+      proton_file:
+      electron_file:
+    output: /fefs/aswg/data/mc/IRF/AllSky/20220913_crab_theta23_tuned/TestingDataset/dec_2276/node_theta_23.630_az_259.265_/irf_20220913_crab_theta23_tuned_node_theta_23.630_az_259.265_.fits.gz
+    options: --point-like


### PR DESCRIPTION
#  20220913_crab_theta23_tuned

Following production `20220902_crab_test_nodes` that had no tuning.


Processing of nodes node_theta_23.630_az_100.758 and node_theta_23.630_az_259.265_ only for:
- dl1ab
    -  with tuned config from [crab tuned prod](https://github.com/cta-observatory/lstmcpipe/blob/master/production_configs/20220518_v0.9.6_allsky_dec2276_tuned/lstchain_config_dec_2276_tuned.json)
- merge
- dl1_to_dl2
    - with trained RF from crab tuned prod: `/fefs/aswg/data/models/AllSky/20220518_allsky_dec2276_tuned/dec_2276`
- dl2_to_irfs

See https://github.com/cta-observatory/lst-sim-config/issues/49#issuecomment-1235392024