### PR TITLE
Smarter prod dl1ab checker

### DIFF
--- a/lstmcpipe/config/paths_config.py
+++ b/lstmcpipe/config/paths_config.py
@@ -989,6 +989,7 @@ class PathConfigAllSkyTestingDL1ab(PathConfigAllSkyTesting):
             self.check_source_prod()
         
     def check_source_prod(self):
+        marked_for_removal = []
         for pointing in self.pointing_dirs():
             source_dl1 = Path(self.source_config.dl1_dir(pointing))
             if not source_dl1.exists():

--- a/lstmcpipe/config/paths_config.py
+++ b/lstmcpipe/config/paths_config.py
@@ -942,17 +942,13 @@ class PathConfigAllSkyTrainingDL1ab(PathConfigAllSkyTraining):
     def check_source_prod(self):
         marked_for_removal = []
         for particle in self.training_particles:
-            for pointing in self.pointing_dirs(particle):
+            for pidx, pointing in enumerate(self.pointing_dirs(particle)):
                 source_dl1 = Path(self.source_config.dl1_dir(particle, pointing))
                 if not source_dl1.exists():
                     warnings.warn(f"{source_dl1} does not exist but MC file for {particle} - {pointing} does. "
                                   f"This node will be removed from production.")
-                    marked_for_removal.append(pointing)
-        for pointing in marked_for_removal:
-            self.remove_pointing(pointing)
-    def remove_pointing(self, pointing):
-        for particle in self.training_particles:
-            self.pointings[particle].remove(pointing)
+                    marked_for_removal.append(pidx)
+        self._training_pointings.remove_rows(pidx)
 
     @property
     def dl1ab(self):
@@ -990,16 +986,13 @@ class PathConfigAllSkyTestingDL1ab(PathConfigAllSkyTesting):
         
     def check_source_prod(self):
         marked_for_removal = []
-        for pointing in self.pointing_dirs():
+        for pidx, pointing in enumerate(self.pointing_dirs()):
             source_dl1 = Path(self.source_config.dl1_dir(pointing))
             if not source_dl1.exists():
                 warnings.warn(f"{source_dl1} does not exist but MC file for {pointing} does. "
                               f"This node will be removed from production.")
-                marked_for_removal.append(pointing)
-        for pointing in marked_for_removal:
-            self.remove_pointing(pointing)
-    def remove_pointing(self, pointing):
-        self.pointings.remove(pointing)
+                marked_for_removal.append(pidx)
+        self._testing_pointings.remove_rows(marked_for_removal)
 
     @property
     def dl1ab(self):

--- a/lstmcpipe/config/paths_config.py
+++ b/lstmcpipe/config/paths_config.py
@@ -992,7 +992,7 @@ class PathConfigAllSkyTestingDL1ab(PathConfigAllSkyTesting):
         for pointing in self.pointing_dirs():
             source_dl1 = Path(self.source_config.dl1_dir(pointing))
             if not source_dl1.exists():
-                warnings.warn(f"{source_dl1} does not exist but MC file for {particle} - {pointing} does. "
+                warnings.warn(f"{source_dl1} does not exist but MC file for {pointing} does. "
                               f"This node will be removed from production.")
                 marked_for_removal.append(pointing)
         for pointing in marked_for_removal:

--- a/lstmcpipe/config/paths_config.py
+++ b/lstmcpipe/config/paths_config.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import warnings
 from pathlib import Path
 from ruamel.yaml import YAML
 from datetime import date

--- a/lstmcpipe/config/paths_config.py
+++ b/lstmcpipe/config/paths_config.py
@@ -939,11 +939,19 @@ class PathConfigAllSkyTrainingDL1ab(PathConfigAllSkyTraining):
             self.check_source_prod()
         
     def check_source_prod(self):
+        marked_for_removal = []
         for particle in self.training_particles:
             for pointing in self.pointing_dirs(particle):
                 source_dl1 = Path(self.source_config.dl1_dir(particle, pointing))
                 if not source_dl1.exists():
-                    raise FileNotFoundError(f"{source_dl1} should exist to run this DL1ab")
+                    warnings.warn(f"{source_dl1} does not exist but MC file for {particle} - {pointing} does. "
+                                  f"This node will be removed from production.")
+                    marked_for_removal.append(pointing)
+        for pointing in marked_for_removal:
+            self.remove_pointing(pointing)
+    def remove_pointing(self, pointing):
+        for particle in self.training_particles:
+            self.pointings[particle].remove(pointing)
 
     @property
     def dl1ab(self):
@@ -983,7 +991,13 @@ class PathConfigAllSkyTestingDL1ab(PathConfigAllSkyTesting):
         for pointing in self.pointing_dirs():
             source_dl1 = Path(self.source_config.dl1_dir(pointing))
             if not source_dl1.exists():
-                raise FileNotFoundError(f"{source_dl1} should exist to run this DL1ab")
+                warnings.warn(f"{source_dl1} does not exist but MC file for {particle} - {pointing} does. "
+                              f"This node will be removed from production.")
+                marked_for_removal.append(pointing)
+        for pointing in marked_for_removal:
+            self.remove_pointing(pointing)
+    def remove_pointing(self, pointing):
+        self.pointings.remove(pointing)
 
     @property
     def dl1ab(self):


### PR DESCRIPTION
When MC nodes are added between production, or if a former prod included only a subset of nodes, it's still fine to be able to run a DL1ab stage on it.

Warn user and remove nodes that won't be included in the production rather than raising a blocking `FileNotFoundError` in DL1ab prods.