### PR TITLE
Bug: fix workflow_step label in log files when dl1ab step is used

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -63,6 +63,17 @@
                 "@type": "Organization",
                 "name": "TU Dortmund University, Department of Physics"
             }
+        },
+        {
+            "@type": "Person",
+            "@id": "https://orcid.org/0000-0001-8816-4920",
+            "givenName": "Arnau",
+            "familyName": "Aguasca-Cabot",
+            "email": "arnau.aguasca@fqa.ub.edu",
+            "affiliation": {
+                "@type": "Organization",
+                "name": "Departament de F\u00edsica Qu\u00e0ntica i Astrof\u00edsica, Institut de Ci\u00e8ncies del Cosmos (ICCUB), Universitat de Barcelona (IEEC-UB)"
+            }
         }
     ],
     "maintainer": {

--- a/lstmcpipe/stages/mc_process_dl1.py
+++ b/lstmcpipe/stages/mc_process_dl1.py
@@ -75,8 +75,12 @@ def batch_process_dl1(dict_paths, conf_file, batch_config, logs, workflow_kind="
             jobids_dl1_processing_stage.append(jobid)
             debug_log[jobid] = f'dl1ab job from input dir: {paths["input"]}'
     jobids_dl1_processing_stage = ",".join(jobids_dl1_processing_stage)
-    save_log_to_file(log_process_dl1, logs["log_file"], "r0_to_dl1")
-    save_log_to_file(debug_log, logs["debug_file"], workflow_step="r0_to_dl1")
+    if new_production:
+        save_log_to_file(log_process_dl1, logs["log_file"], "r0_to_dl1")
+        save_log_to_file(debug_log, logs["debug_file"], workflow_step="r0_to_dl1")
+    else:
+        save_log_to_file(log_process_dl1, logs["log_file"], "dl1ab")
+        save_log_to_file(debug_log, logs["debug_file"], workflow_step="dl1ab")
     log.info(f"==== END {workflow_kind} dl1 processing ====")
     return jobids_dl1_processing_stage
 


### PR DESCRIPTION
When the lstmcpipe is run using the dl1ab step, the workflow_step label `r0_to_dl1` appears instead of the `dl1ab` in the log_reduced*.yml and log_lstmcpipe_*.yml files.

This PR should fix this bug.