### PR TITLE
Seasonal atmosphere

### DIFF
--- a/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/20231017_v0.10.4_seasonal_atmospheres_summer_full.yaml
+++ b/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/20231017_v0.10.4_seasonal_atmospheres_summer_full.yaml
@@ -49,7 +49,7 @@ stages:
       proton: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/summer/Protons/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
     output: /fefs/aswg/data/models/AllSky/20231017_v0.10.4_seasonal_atmospheres/summer
     slurm_options: -p xxl --mem=100G --cpus-per-task=16
-  - input:	      
+  - input:      
       gamma: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
       proton: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/Protons/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
     output: /fefs/aswg/data/models/AllSky/20231017_v0.10.4_seasonal_atmospheres/winter

--- a/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/20231017_v0.10.4_seasonal_atmospheres_summer_full.yaml
+++ b/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/20231017_v0.10.4_seasonal_atmospheres_summer_full.yaml
@@ -63,7 +63,6 @@ stages:
     path_model: /fefs/aswg/data/models/AllSky/20231017_v0.10.4_seasonal_atmospheres/winter
     output: /fefs/aswg/data/mc/DL2/AllSky/20231017_v0.10.4_seasonal_atmospheres/summer/winter_models/node_theta_23.63_az_100.758_
     slurm_options: --mem=50GB
-
   dl2_to_irfs:
   - input:
       gamma_file: /fefs/aswg/data/mc/DL2/AllSky/20231017_v0.10.4_seasonal_atmospheres/summer/summer_models/node_theta_23.63_az_100.758_/dl2_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5

--- a/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/20231017_v0.10.4_seasonal_atmospheres_summer_full.yaml
+++ b/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/20231017_v0.10.4_seasonal_atmospheres_summer_full.yaml
@@ -7,7 +7,7 @@ source_environment:
   conda_env: lstchain-v0.10.4
 
 slurm_config:
-  user_account: georgios.voutsinas
+  user_account: dpps
 
 stages_to_run:
 - r0_to_dl1
@@ -23,6 +23,10 @@ stages:
     output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/Protons/node_corsika_theta_23.161_az_99.261_/DL1
   - input: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/sim_telarray/output_v1.4
     output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1
+  - input: /fefs/aswg/data/mc/DL0/LSTProd2/TrainingDataset/Protons/dec_2276/sim_telarray/node_theta_23.161_az_99.261_/output_v1.4
+    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/Protons/node_corsika_theta_23.161_az_99.261_/DL1
+  - input: /fefs/aswg/data/mc/DL0/LSTProd2/TrainingDataset/GammaDiffuse/dec_2276/sim_telarray/node_corsika_theta_23.161_az_99.261_/output_v1.4
+    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1
   merge_dl1:
   - input:  /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL1/summer/node_theta_23.63_az_100.758_
     output: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL1/summer/node_theta_23.63_az_100.758_/dl1_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
@@ -33,19 +37,37 @@ stages:
   - input: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1
     output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
     options: --no-image    
+  - input: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/Protons/node_corsika_theta_23.161_az_99.261_/DL1
+    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/Protons/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
+  - input: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1
+    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
   train_pipe:
   - input:
       gamma: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
       proton: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/Protons/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
-    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/models
+    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/summer_models
+    slurm_options: -p xxl --mem=32G --cpus-per-task=16
+    - input:	   
+      gamma: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
+      proton: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/Protons/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
+    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/winter_models
     slurm_options: -p xxl --mem=32G --cpus-per-task=16
   dl1_to_dl2:
   - input: home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL1/summer/node_theta_23.63_az_100.758_/dl1_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
-    path_model: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/models
-    output: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL2/summer/node_theta_23.63_az_100.758_
+    path_model: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/summer_models
+    output: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL2/summer/summer_models/node_theta_23.63_az_100.758_
     slurm_options: --mem=50GB
+  - input: home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL1/summer/node_theta_23.63_az_100.758_/dl1_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
+    path_model: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/winter_models
+    output: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL2/summer/winter_models/node_theta_23.63_az_100.758_
+    slurm_options: --mem=50GB
+
   dl2_to_irfs:
   - input:
-      gamma_file: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL2/summer/node_theta_23.63_az_100.758_/dl2_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
+      gamma_file: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL2/summer/summer_models/node_theta_23.63_az_100.758_/dl2_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
+      proton_file:
+      electron_file:
+  - input: 
+      gamma_file: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL2/summer/winter_models/node_theta_23.63_az_100.758_/dl2_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
       proton_file:
       electron_file:

--- a/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/20231017_v0.10.4_seasonal_atmospheres_summer_full.yaml
+++ b/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/20231017_v0.10.4_seasonal_atmospheres_summer_full.yaml
@@ -1,0 +1,51 @@
+workflow_kind: lstchain
+
+prod_id: 20231017_v0.10.4_seasonal_atmospheres_summer
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.10.4
+
+slurm_config:
+  user_account: georgios.voutsinas
+
+stages_to_run:
+- r0_to_dl1
+- merge_dl1
+- train_pipe
+- dl1_to_dl2
+- dl2_to_irfs
+stages:
+  r0_to_dl1:
+  - input: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/sim_telarray/summer/node_theta_23.63_az_100.758_/output_v1.4
+    output: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL1/summer/node_theta_23.63_az_100.758_
+  - input: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/Protons/node_corsika_theta_23.161_az_99.261_/sim_telarray/output_v1.4
+    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/Protons/node_corsika_theta_23.161_az_99.261_/DL1
+  - input: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/sim_telarray/output_v1.4
+    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1
+  merge_dl1:
+  - input:  /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL1/summer/node_theta_23.63_az_100.758_
+    output: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL1/summer/node_theta_23.63_az_100.758_/dl1_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
+    options: --no-image
+  - input: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/Protons/node_corsika_theta_23.161_az_99.261_/DL1
+    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/Protons/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
+    options: --no-image
+  - input: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1
+    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
+    options: --no-image    
+  train_pipe:
+  - input:
+      gamma: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
+      proton: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/Protons/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
+    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/models
+    slurm_options: -p xxl --mem=32G --cpus-per-task=16
+  dl1_to_dl2:
+  - input: home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL1/summer/node_theta_23.63_az_100.758_/dl1_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
+    path_model: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/models
+    output: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL2/summer/node_theta_23.63_az_100.758_
+    slurm_options: --mem=50GB
+  dl2_to_irfs:
+  - input:
+      gamma_file: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL2/summer/node_theta_23.63_az_100.758_/dl2_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
+      proton_file:
+      electron_file:

--- a/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/20231017_v0.10.4_seasonal_atmospheres_summer_full.yaml
+++ b/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/20231017_v0.10.4_seasonal_atmospheres_summer_full.yaml
@@ -18,56 +18,64 @@ stages_to_run:
 stages:
   r0_to_dl1:
   - input: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/sim_telarray/summer/node_theta_23.63_az_100.758_/output_v1.4
-    output: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL1/summer/node_theta_23.63_az_100.758_
+    output: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TestingDataset/summer/node_theta_23.63_az_100.758_
   - input: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/Protons/node_corsika_theta_23.161_az_99.261_/sim_telarray/output_v1.4
-    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/Protons/node_corsika_theta_23.161_az_99.261_/DL1
+    output: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/summer/Protons/node_corsika_theta_23.161_az_99.261_
   - input: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/sim_telarray/output_v1.4
-    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1
+    output:  /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_
   - input: /fefs/aswg/data/mc/DL0/LSTProd2/TrainingDataset/Protons/dec_2276/sim_telarray/node_theta_23.161_az_99.261_/output_v1.4
-    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/Protons/node_corsika_theta_23.161_az_99.261_/DL1
+    output: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/Protons/node_corsika_theta_23.161_az_99.261_
   - input: /fefs/aswg/data/mc/DL0/LSTProd2/TrainingDataset/GammaDiffuse/dec_2276/sim_telarray/node_corsika_theta_23.161_az_99.261_/output_v1.4
-    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1
+    output: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_
   merge_dl1:
-  - input:  /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL1/summer/node_theta_23.63_az_100.758_
-    output: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL1/summer/node_theta_23.63_az_100.758_/dl1_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TestingDataset/summer/node_theta_23.63_az_100.758_
+    output: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TestingDataset/summer/node_theta_23.63_az_100.758_/dl1_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
     options: --no-image
-  - input: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/Protons/node_corsika_theta_23.161_az_99.261_/DL1
-    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/Protons/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/summer/Protons/node_corsika_theta_23.161_az_99.261_
+    output: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/summer/Protons/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
     options: --no-image
-  - input: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1
-    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_
+    output: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
     options: --no-image    
-  - input: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/Protons/node_corsika_theta_23.161_az_99.261_/DL1
-    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/Protons/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
-  - input: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1
-    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/Protons/node_corsika_theta_23.161_az_99.261_
+    output: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/Protons/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_
+    output: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
   train_pipe:
   - input:
-      gamma: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
-      proton: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/Protons/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
-    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/summer_models
-    slurm_options: -p xxl --mem=32G --cpus-per-task=16
-    - input:	   
-      gamma: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
-      proton: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/winter/Protons/node_corsika_theta_23.161_az_99.261_/DL1/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
-    output: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/winter_models
-    slurm_options: -p xxl --mem=32G --cpus-per-task=16
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/summer/Protons/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20231017_v0.10.4_seasonal_atmospheres/summer
+    slurm_options: -p xxl --mem=100G --cpus-per-task=16
+    - input:	      
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/Protons/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20231017_v0.10.4_seasonal_atmospheres/winter
+    slurm_options: -p xxl --mem=100G --cpus-per-task=16
   dl1_to_dl2:
-  - input: home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL1/summer/node_theta_23.63_az_100.758_/dl1_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
-    path_model: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/summer_models
-    output: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL2/summer/summer_models/node_theta_23.63_az_100.758_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TestingDataset/summer/node_theta_23.63_az_100.758_/dl1_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20231017_v0.10.4_seasonal_atmospheres/summer
+    output: /fefs/aswg/data/mc/DL2/AllSky/20231017_v0.10.4_seasonal_atmospheres/summer/summer_models/node_theta_23.63_az_100.758_
     slurm_options: --mem=50GB
-  - input: home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL1/summer/node_theta_23.63_az_100.758_/dl1_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
-    path_model: /home/georgios.voutsinas/ws/AllSky/TrainingDataset/atmosphere/summer/winter_models
-    output: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL2/summer/winter_models/node_theta_23.63_az_100.758_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TestingDataset/summer/node_theta_23.63_az_100.758_/dl1_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20231017_v0.10.4_seasonal_atmospheres/winter
+    output: /fefs/aswg/data/mc/DL2/AllSky/20231017_v0.10.4_seasonal_atmospheres/summer/winter_models/node_theta_23.63_az_100.758_
     slurm_options: --mem=50GB
 
   dl2_to_irfs:
   - input:
-      gamma_file: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL2/summer/summer_models/node_theta_23.63_az_100.758_/dl2_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
+      gamma_file: /fefs/aswg/data/mc/DL2/AllSky/20231017_v0.10.4_seasonal_atmospheres/summer/summer_models/node_theta_23.63_az_100.758_/dl2_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
       proton_file:
       electron_file:
+    output: /fefs/aswg/data/mc/IRF/AllSky/20231017_v0.10.4_seasonal_atmospheres/TestingDataset/summer_summer_models/node_theta_23.63_az_100.758_/irf_20231017_v0.10.4_seasonal_atmospheres_node_theta_23.63_az_100.758_.fits.gz
+    options: --point-like
+    extra_slurm_options:
+      mem: 6GB
   - input: 
-      gamma_file: /home/georgios.voutsinas/ws/AllSky/TestDataset/atmosphere/DL2/summer/winter_models/node_theta_23.63_az_100.758_/dl2_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
+      gamma_file: /fefs/aswg/data/mc/DL2/AllSky/20231017_v0.10.4_seasonal_atmospheres/summer/winter_models/node_theta_23.63_az_100.758_/dl2_20231017_v.0.10.4_summer_node_theta_23.63_az_100.758_merged.h5
       proton_file:
       electron_file:
+    output: /fefs/aswg/data/mc/IRF/AllSky/20231017_v0.10.4_seasonal_atmospheres/TestingDataset/summer_winter_models/node_theta_23.63_az_100.758_/irf_20231017_v0.10.4_seasonal_atmospheres_node_theta_23.63_az_100.758_.fits.gz
+    options: --point-like
+    extra_slurm_options:
+      mem: 6GB

--- a/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/20231017_v0.10.4_seasonal_atmospheres_summer_full.yaml
+++ b/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/20231017_v0.10.4_seasonal_atmospheres_summer_full.yaml
@@ -39,15 +39,17 @@ stages:
     options: --no-image    
   - input: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/Protons/node_corsika_theta_23.161_az_99.261_
     output: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/Protons/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
+    options: --no-image
   - input: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_
     output: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
+    options: --no-image
   train_pipe:
   - input:
       gamma: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/summer/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
       proton: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/summer/Protons/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_summer_node_corsika_theta_23.161_az_99.261_merged.h5
     output: /fefs/aswg/data/models/AllSky/20231017_v0.10.4_seasonal_atmospheres/summer
     slurm_options: -p xxl --mem=100G --cpus-per-task=16
-    - input:	      
+  - input:	      
       gamma: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/GammaDiffuse/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
       proton: /fefs/aswg/data/mc/DL1/AllSky/20231017_v0.10.4_seasonal_atmospheres/TrainingDataset/winter/Protons/node_corsika_theta_23.161_az_99.261_/dl1_20231017_v.0.10.4_winter_node_corsika_theta_23.161_az_99.261_merged.h5
     output: /fefs/aswg/data/models/AllSky/20231017_v0.10.4_seasonal_atmospheres/winter

--- a/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/lstchain_config_2023_10_17.json
+++ b/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/lstchain_config_2023_10_17.json
@@ -1,0 +1,322 @@
+{
+    "source_config": {
+        "EventSource": {
+            "allowed_tels": [
+                1
+            ],
+            "max_events": null
+        },
+        "LSTEventSource": {
+            "default_trigger_type": "ucts",
+            "allowed_tels": [
+                1
+            ],
+            "min_flatfield_adc": 3000,
+            "min_flatfield_pixel_fraction": 0.8,
+            "calibrate_flatfields_and_pedestals": false,
+            "EventTimeCalculator": {
+                "dragon_reference_counter": null,
+                "dragon_reference_time": null
+            },
+            "PointingSource": {
+                "drive_report_path": null
+            },
+            "LSTR0Corrections": {
+                "calib_scale_high_gain": 1.088,
+                "calib_scale_low_gain": 1.004,
+                "drs4_pedestal_path": null,
+                "calibration_path": null,
+                "drs4_time_calibration_path": null
+            }
+        }
+    },
+    "events_filters": {
+        "intensity": [
+            0,
+            Infinity
+        ],
+        "width": [
+            0,
+            Infinity
+        ],
+        "length": [
+            0,
+            Infinity
+        ],
+        "wl": [
+            0,
+            Infinity
+        ],
+        "r": [
+            0,
+            Infinity
+        ],
+        "leakage_intensity_width_2": [
+            0,
+            Infinity
+        ]
+    },
+    "n_training_events": {
+        "gamma_regressors": 1.0,
+        "gamma_tmp_regressors": 0.8,
+        "gamma_classifier": 0.2,
+        "proton_classifier": 1.0
+    },
+    "tailcut": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "sigma": 2.5,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "dynamic_cleaning": {
+        "apply": true,
+        "threshold": 267,
+        "fraction_cleaning_intensity": 0.03
+    },
+    "random_forest_energy_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "warm_start": false
+    },
+    "random_forest_disp_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "warm_start": false
+    },
+    "random_forest_disp_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "random_forest_particle_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "energy_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2",
+        "sin_az_tel",
+        "alt_tel"
+    ],
+    "disp_method": "disp_norm_sign",
+    "disp_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2",
+        "sin_az_tel",
+        "alt_tel"
+    ],
+    "disp_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2",
+        "sin_az_tel",
+        "alt_tel"
+    ],
+    "particle_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "signed_skewness",
+        "kurtosis",
+        "signed_time_gradient",
+        "leakage_intensity_width_2",
+        "log_reco_energy",
+        "reco_disp_norm",
+        "reco_disp_sign",
+        "sin_az_tel",
+        "alt_tel"
+    ],
+    "allowed_tels": [
+        1
+    ],
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+        "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "timestamps_pointing": "ucts",
+    "train_gamma_src_r_deg": [
+        0,
+        Infinity
+    ],
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+    "volume_reducer": {
+        "algorithm": null,
+        "parameters": {}
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+    "LSTCalibrationCalculator": {
+        "systematic_correction_path": null,
+        "npe_median_cut_outliers": [
+            -5,
+            5
+        ],
+        "squared_excess_noise_factor": 1.222,
+        "flatfield_product": "FlasherFlatFieldCalculator",
+        "pedestal_product": "PedestalIntegrator",
+        "PedestalIntegrator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_median_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_product": "FixedWindowSum",
+            "FixedWindowSum": {
+                "window_shift": 6,
+                "window_width": 12,
+                "peak_index": 18,
+                "apply_integration_correction": false
+            }
+        },
+        "FlasherFlatFieldCalculator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_product": "LocalPeakWindowSum",
+            "charge_median_cut_outliers": [
+                -0.9,
+                2
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "time_cut_outliers": [
+                2,
+                38
+            ],
+            "LocalPeakWindowSum": {
+                "window_shift": 5,
+                "window_width": 12,
+                "apply_integration_correction": false
+            }
+        }
+    },
+    "waveform_nsb_tuning": {
+        "nsb_tuning": false,
+        "nsb_tuning_ratio": 0.52,
+        "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    },
+    "write_interleaved_events": {
+        "DataWriter": {
+            "overwrite": true,
+            "write_images": false,
+            "write_parameters": false,
+            "write_waveforms": true,
+            "transform_waveform": true,
+            "waveform_dtype": "uint16",
+            "waveform_offset": 400,
+            "waveform_scale": 80
+        }
+    },
+    "image_modifier":    {
+          "increase_nsb": true,
+          "extra_noise_in_dim_pixels": 2.197,
+          "extra_bias_in_dim_pixels": 0.82,
+          "transition_charge": 8,
+          "extra_noise_in_bright_pixels": 2.88
+    }
+}

--- a/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/readme.md
+++ b/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/readme.md
@@ -4,7 +4,7 @@ Full production of a test node simulated with a summer atmospheric profile.
 Reconstructed with 
  - training datasets produced with the same atmosphere as for the production.
  - training datasets produced with the standard average winter atmospheric profile.
- - 
+
 The goal is to estimate the systematics introduced by using the same average winter atmospheric profile 
 in order to analyse all LST data.
 

--- a/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/readme.md
+++ b/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/readme.md
@@ -4,6 +4,7 @@ Full production of a test node simulated with a summer atmospheric profile.
 Reconstructed with 
  - training datasets produced with the same atmosphere as for the production.
  - training datasets produced with the standard average winter atmospheric profile.
+ - 
 The goal is to estimate the systematics introduced by using the same average winter atmospheric profile 
 in order to analyse all LST data.
 

--- a/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/readme.md
+++ b/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/readme.md
@@ -1,7 +1,9 @@
 # 20231017_v0.10.4_seasonal_atmospheres_summer
 
 Full production of a test node simulated with a summer atmospheric profile. 
-Reconstructed with random forests simulated with the same atmosphere.
+Reconstructed with 
+ - training datasets produced with the same atmosphere as for the production.
+ - training datasets produced with the standard average winter atmospheric profile.
 The goal is to estimate the systematics introduced by using the same average winter atmospheric profile 
 in order to analyse all LST data.
 

--- a/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/readme.md
+++ b/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/readme.md
@@ -1,0 +1,10 @@
+# 20231017_v0.10.4_seasonal_atmospheres_summer
+
+Full production of a test node simulated with a summer atmospheric profile. 
+Reconstructed with random forests simulated with the same atmosphere.
+The goal is to estimate the systematics introduced by using the same average winter atmospheric profile 
+in order to analyse all LST data.
+
+Contact : Georgios Voutsinas
+
+

--- a/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/readme.md
+++ b/production_configs/20231017_v0.10.4_seasonal_atmospheres_summer/readme.md
@@ -8,6 +8,8 @@ Reconstructed with
 The goal is to estimate the systematics introduced by using the same average winter atmospheric profile 
 in order to analyse all LST data.
 
+The config file was created manually, inspired by the configurations of the production 20230927_v0.10.4_crab_tuned.
+
 Contact : Georgios Voutsinas
 
 


### PR DESCRIPTION
<!---  
You may leave this message, it will be commented out in your PR.
- if you are requesting a new config to be processed, please use the New Prod Config template
- if you are proposing changes to lstmcpipe library delete the template and describe your PR as usual
--->

<!---  
New Prod Config template
Add Prod_ID and fill the template
Your Pull Request must include the following files placed in directory `production_configs/prod_id`:
- lstmcpipe config file
- lstchain config
- readme.md

Add label `new_prod_config`
---> 

# New Prod config

Self check-list:

- [ ] I have checked the lstchain config, in particular for:
  - [ ] `az_tel` instead of `sin_az_tel` if data to be analyzed have been produced with lstchain <= v0.9.7
  - [ ] "increase_nsb" and "increase_psf" are provided in "image_modifier" (if used)
- [ ] I have checked the environment in the lstmcpipe config and it is the one used to analyse DL>1 data
- [ ] I have provided the command (in README), or script (in additionnal .py file) used to produce the lstmcpipe config

## Prod_ID

20231017_v0.10.4_seasonal_atmospheres_summer

## Short description of the config
Full production of a test node simulated with a summer atmospheric profile. Reconstructed with
 - training datasets produced with the same atmosphere as for the production.
 - training datasets produced with the standard average winter atmospheric profile.

## Why this config is needed 
The goal is to estimate the systematics introduced by using the same average winter atmospheric profile in order to analyse all LST data.