### PR TITLE
20240219_allsky_v0.10.7_all_dec_srcdep_base production

### DIFF
--- a/production_configs/20240219_allsky_v0.10.7_all_dec_srcdep_base/README.md
+++ b/production_configs/20240219_allsky_v0.10.7_all_dec_srcdep_base/README.md
@@ -1,4 +1,4 @@
-# Prod 20240131_allsky_v0.10.5_all_dec_base
+# Prod 20240219_allsky_v0.10.7_all_dec_srcdep_base
 
 Base production for all declinations lines with lstchain v0.10.7 & source-dependent approach
 

--- a/production_configs/20240219_allsky_v0.10.7_all_dec_srcdep_base/README.md
+++ b/production_configs/20240219_allsky_v0.10.7_all_dec_srcdep_base/README.md
@@ -1,0 +1,14 @@
+# Prod 20240131_allsky_v0.10.5_all_dec_base
+
+Base production for all declinations lines with lstchain v0.10.7 & source-dependent approach
+
+
+```
+lstmcpipe_generate_config PathConfigAllTrainTestDL1b --dec_list dec_2276 dec_4822 dec_6166 dec_6676 dec_min_1802 dec_min_413 dec_931 dec_min_2924 dec_3476 --prod_id 20240219_allsky_v0.10.7_all_dec_srcdep_base --kwargs source_prod_id=20240131_allsky_v0.10.5_all_dec_base
+```
+
+```
+lstchain_dump_config -o lstchain_config_2024-02-19_srcdep.json --mc --update-with lstchain_src_dep_config.json
+```
+
+contact: Seiya N.

--- a/production_configs/20240219_allsky_v0.10.7_all_dec_srcdep_base/lstchain_config_2024-02-19_srcdep.json
+++ b/production_configs/20240219_allsky_v0.10.7_all_dec_srcdep_base/lstchain_config_2024-02-19_srcdep.json
@@ -1,0 +1,318 @@
+{
+  "source_config": {
+    "EventSource": {
+      "allowed_tels": [
+        1
+      ],
+      "max_events": null
+    },
+    "LSTEventSource": {
+      "default_trigger_type": "ucts",
+      "allowed_tels": [
+        1
+      ],
+      "min_flatfield_adc": 3000,
+      "min_flatfield_pixel_fraction": 0.8,
+      "calibrate_flatfields_and_pedestals": false,
+      "EventTimeCalculator": {
+        "dragon_reference_counter": null,
+        "dragon_reference_time": null
+      },
+      "PointingSource": {
+        "drive_report_path": null
+      },
+      "LSTR0Corrections": {
+        "calib_scale_high_gain": 1.088,
+        "calib_scale_low_gain": 1.004,
+        "drs4_pedestal_path": null,
+        "calibration_path": null,
+        "drs4_time_calibration_path": null
+      }
+    }
+  },
+  "events_filters": {
+    "intensity": [
+      0,
+      Infinity
+    ],
+    "width": [
+      0,
+      Infinity
+    ],
+    "length": [
+      0,
+      Infinity
+    ],
+    "wl": [
+      0,
+      Infinity
+    ],
+    "r": [
+      0,
+      Infinity
+    ],
+    "leakage_intensity_width_2": [
+      0,
+      Infinity
+    ]
+  },
+  "n_training_events": {
+    "gamma_regressors": 1.0,
+    "gamma_tmp_regressors": 0.8,
+    "gamma_classifier": 0.2,
+    "proton_classifier": 1.0
+  },
+  "tailcut": {
+    "picture_thresh": 8,
+    "boundary_thresh": 4,
+    "keep_isolated_pixels": false,
+    "min_number_picture_neighbors": 2,
+    "use_only_main_island": false,
+    "delta_time": 2
+  },
+  "tailcuts_clean_with_pedestal_threshold": {
+    "picture_thresh": 8,
+    "boundary_thresh": 4,
+    "sigma": 2.5,
+    "keep_isolated_pixels": false,
+    "min_number_picture_neighbors": 2,
+    "use_only_main_island": false,
+    "delta_time": 2
+  },
+  "dynamic_cleaning": {
+    "apply": true,
+    "threshold": 267,
+    "fraction_cleaning_intensity": 0.03
+  },
+  "random_forest_energy_regressor_args": {
+    "max_depth": 30,
+    "min_samples_leaf": 10,
+    "n_jobs": -1,
+    "n_estimators": 150,
+    "bootstrap": true,
+    "criterion": "squared_error",
+    "max_features": "auto",
+    "max_leaf_nodes": null,
+    "min_impurity_decrease": 0.0,
+    "min_samples_split": 10,
+    "min_weight_fraction_leaf": 0.0,
+    "oob_score": false,
+    "random_state": 42,
+    "warm_start": false
+  },
+  "random_forest_disp_regressor_args": {
+    "max_depth": 30,
+    "min_samples_leaf": 10,
+    "n_jobs": -1,
+    "n_estimators": 150,
+    "bootstrap": true,
+    "criterion": "squared_error",
+    "max_features": "auto",
+    "max_leaf_nodes": null,
+    "min_impurity_decrease": 0.0,
+    "min_samples_split": 10,
+    "min_weight_fraction_leaf": 0.0,
+    "oob_score": false,
+    "random_state": 42,
+    "warm_start": false
+  },
+  "random_forest_disp_classifier_args": {
+    "max_depth": 30,
+    "min_samples_leaf": 10,
+    "n_jobs": -1,
+    "n_estimators": 100,
+    "criterion": "gini",
+    "min_samples_split": 10,
+    "min_weight_fraction_leaf": 0.0,
+    "max_features": "auto",
+    "max_leaf_nodes": null,
+    "min_impurity_decrease": 0.0,
+    "bootstrap": true,
+    "oob_score": false,
+    "random_state": 42,
+    "warm_start": false,
+    "class_weight": null
+  },
+  "random_forest_particle_classifier_args": {
+    "max_depth": 30,
+    "min_samples_leaf": 10,
+    "n_jobs": -1,
+    "n_estimators": 100,
+    "criterion": "gini",
+    "min_samples_split": 10,
+    "min_weight_fraction_leaf": 0.0,
+    "max_features": "auto",
+    "max_leaf_nodes": null,
+    "min_impurity_decrease": 0.0,
+    "bootstrap": true,
+    "oob_score": false,
+    "random_state": 42,
+    "warm_start": false,
+    "class_weight": null
+  },
+  "energy_regression_features": [
+    "log_intensity",
+    "width",
+    "length",
+    "wl",
+    "skewness_from_source",
+    "kurtosis",
+    "time_gradient_from_source",
+    "leakage_intensity_width_2",
+    "dist",
+    "alt_tel",
+    "sin_az_tel"
+  ],
+  "disp_method": "disp_norm_sign",
+  "disp_regression_features": [
+    "log_intensity",
+    "width",
+    "length",
+    "wl",
+    "skewness",
+    "kurtosis",
+    "time_gradient",
+    "leakage_intensity_width_2",
+    "alt_tel",
+    "sin_az_tel"
+  ],
+  "disp_classification_features": [
+    "log_intensity",
+    "width",
+    "length",
+    "wl",
+    "skewness",
+    "kurtosis",
+    "time_gradient",
+    "leakage_intensity_width_2",
+    "alt_tel",
+    "sin_az_tel"
+  ],
+  "particle_classification_features": [
+    "log_intensity",
+    "width",
+    "length",
+    "wl",
+    "skewness_from_source",
+    "kurtosis",
+    "time_gradient_from_source",
+    "leakage_intensity_width_2",
+    "log_reco_energy",
+    "dist",
+    "reco_disp_norm_diff",
+    "reco_disp_sign_correctness",
+    "alt_tel",
+    "sin_az_tel"
+  ],
+  "allowed_tels": [
+    1
+  ],
+  "write_pe_image": false,
+  "mc_image_scaling_factor": 1,
+  "image_extractor": "LocalPeakWindowSum",
+  "image_extractor_for_muons": "GlobalPeakWindowSum",
+  "CameraCalibrator": {
+    "apply_waveform_time_shift": false
+  },
+  "time_sampling_correction_path": "default",
+  "LocalPeakWindowSum": {
+    "window_shift": 4,
+    "window_width": 8,
+    "apply_integration_correction": true
+  },
+  "GlobalPeakWindowSum": {
+    "window_shift": 4,
+    "window_width": 8,
+    "apply_integration_correction": true
+  },
+  "timestamps_pointing": "ucts",
+  "train_gamma_src_r_deg": [
+    0,
+    1.0
+  ],
+  "source_dependent": true,
+  "mc_nominal_source_x_deg": 0.4,
+  "mc_nominal_source_y_deg": 0.0,
+  "volume_reducer": {
+    "algorithm": null,
+    "parameters": {}
+  },
+  "calibration_product": "LSTCalibrationCalculator",
+  "LSTCalibrationCalculator": {
+    "systematic_correction_path": null,
+    "npe_median_cut_outliers": [
+      -5,
+      5
+    ],
+    "squared_excess_noise_factor": 1.222,
+    "flatfield_product": "FlasherFlatFieldCalculator",
+    "pedestal_product": "PedestalIntegrator",
+    "PedestalIntegrator": {
+      "sample_size": 10000,
+      "sample_duration": 100000,
+      "tel_id": 1,
+      "time_sampling_correction_path": null,
+      "charge_median_cut_outliers": [
+        -10,
+        10
+      ],
+      "charge_std_cut_outliers": [
+        -10,
+        10
+      ],
+      "charge_product": "FixedWindowSum",
+      "FixedWindowSum": {
+        "window_shift": 6,
+        "window_width": 12,
+        "peak_index": 18,
+        "apply_integration_correction": false
+      }
+    },
+    "FlasherFlatFieldCalculator": {
+      "sample_size": 10000,
+      "sample_duration": 100000,
+      "tel_id": 1,
+      "time_sampling_correction_path": null,
+      "charge_product": "LocalPeakWindowSum",
+      "charge_median_cut_outliers": [
+        -0.9,
+        2
+      ],
+      "charge_std_cut_outliers": [
+        -10,
+        10
+      ],
+      "time_cut_outliers": [
+        2,
+        38
+      ],
+      "LocalPeakWindowSum": {
+        "window_shift": 5,
+        "window_width": 12,
+        "apply_integration_correction": false
+      }
+    }
+  },
+  "waveform_nsb_tuning": {
+    "nsb_tuning": false,
+    "nsb_tuning_ratio": 0.52,
+    "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+  },
+  "write_interleaved_events": {
+    "DataWriter": {
+      "overwrite": true,
+      "write_images": false,
+      "write_parameters": false,
+      "write_waveforms": true,
+      "transform_waveform": true,
+      "waveform_dtype": "uint16",
+      "waveform_offset": 400,
+      "waveform_scale": 80
+    }
+  },
+  "observation_mode": "wobble",
+  "n_off_wobble": 1,
+  "source_name": "Crab Nebula",
+  "source_ra": 83.63308333,
+  "source_dec": 22.0145
+}

--- a/production_configs/20240219_allsky_v0.10.7_all_dec_srcdep_base/lstmcpipe_config_2024-02-19_PathConfigAllTrainTestDL1b.yaml
+++ b/production_configs/20240219_allsky_v0.10.7_all_dec_srcdep_base/lstmcpipe_config_2024-02-19_PathConfigAllTrainTestDL1b.yaml
@@ -1,0 +1,7681 @@
+# lstmcpipe generated config from PathConfigAllTrainTestDL1b - 2024-02-19
+
+workflow_kind: lstchain
+
+# prod_id ex: local_no_n_islands. Default; v00 (if key left empty or None)
+prod_id: 20240219_allsky_v0.10.7_all_dec_srcdep_base
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.10.7
+
+slurm_config:
+# dpps is the default account for lstanalyzer - other users should use aswg
+  user_account: dpps
+lstmcpipe_version: 0.10.5.dev1+g65fe895
+prod_type: PathConfigAllTrainTestDL1b
+stages_to_run:
+- train_pipe
+- dl1_to_dl2
+stages:
+  train_pipe:
+  - input:
+      gamma: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_min_413/GammaDiffuse/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_min_413_GammaDiffuse_merged.h5
+      proton: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_min_413/Protons/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_min_413_Protons_merged.h5
+    output: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+  - input:
+      gamma: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_6676/GammaDiffuse/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_6676_GammaDiffuse_merged.h5
+      proton: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_6676/Protons/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_6676_Protons_merged.h5
+    output: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+  - input:
+      gamma: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_min_2924/GammaDiffuse/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_min_2924_GammaDiffuse_merged.h5
+      proton: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_min_2924/Protons/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_min_2924_Protons_merged.h5
+    output: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+  - input:
+      gamma: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_2276/GammaDiffuse/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_2276_GammaDiffuse_merged.h5
+      proton: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_2276/Protons/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_2276_Protons_merged.h5
+    output: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    extra_slurm_options:
+      partition: xxl
+      mem: 160G
+      cpus-per-task: 16
+  - input:
+      gamma: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_6166/GammaDiffuse/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_6166_GammaDiffuse_merged.h5
+      proton: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_6166/Protons/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_6166_Protons_merged.h5
+    output: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+  - input:
+      gamma: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_931/GammaDiffuse/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_931_GammaDiffuse_merged.h5
+      proton: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_931/Protons/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_931_Protons_merged.h5
+    output: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+  - input:
+      gamma: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_3476/GammaDiffuse/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_3476_GammaDiffuse_merged.h5
+      proton: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_3476/Protons/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_3476_Protons_merged.h5
+    output: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+  - input:
+      gamma: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_4822/GammaDiffuse/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_4822_GammaDiffuse_merged.h5
+      proton: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_4822/Protons/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_4822_Protons_merged.h5
+    output: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+  - input:
+      gamma: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_min_1802/GammaDiffuse/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_min_1802_GammaDiffuse_merged.h5
+      proton: 
+        /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TrainingDataset/dec_min_1802/Protons/dl1_20240131_allsky_v0.10.5_all_dec_base_dec_min_1802_Protons_merged.h5
+    output: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+  dl1_to_dl2:
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_331.979__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_330.659__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_28.023__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_87.604__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_283.075__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_216.698__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_327.483__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_197.973__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_110.312__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_230.005__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_327.238__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_248.117__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_17.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_29.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_231.243__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_30.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_241.301__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_32.736__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_99.126__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_251.19__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_27.273__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_29.341__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_248.099__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_32.039__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_100.758__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_126.498__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_206.875__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_133.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_203.916__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_318.974__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_24.333__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_32.762__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_327.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_327.23__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_136.586__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_214.263__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_109.015__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_333.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_146.4__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_79.122__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_301.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_327.264__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_102.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_223.818__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_32.671__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_327.694__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_30.246__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_31.603__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_262.712__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_208.633__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_49.119__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_32.381__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_67.271__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_102.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_30.445__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_32.77__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_143.441__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_342.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_328.397__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_28.021__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_328.283__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_26.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_335.667__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_32.786__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_32.306__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_213.73__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_120.311__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_327.961__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_271.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_329.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_327.214__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_331.977__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_259.265__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_31.717__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_136.053__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_329.555__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_329.754__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_331.291__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_330.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_327.329__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_31.342__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_332.727__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_240.004__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_141.683__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_32.517__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_119.073__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_152.343__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_28.709__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_413
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_413/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_331.979__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_330.659__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_28.023__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_87.604__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_283.075__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_216.698__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_327.483__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_197.973__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_110.312__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_230.005__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_327.238__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_248.117__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_17.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_29.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_231.243__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_30.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_241.301__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_32.736__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_99.126__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_251.19__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_27.273__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_29.341__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_248.099__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_32.039__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_100.758__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_126.498__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_206.875__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_133.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_203.916__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_318.974__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_24.333__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_32.762__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_327.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_327.23__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_136.586__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_214.263__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_109.015__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_333.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_146.4__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_79.122__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_301.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_327.264__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_102.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_223.818__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_32.671__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_327.694__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_30.246__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_31.603__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_262.712__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_208.633__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_49.119__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_32.381__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_67.271__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_102.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_30.445__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_32.77__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_143.441__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_342.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_328.397__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_28.021__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_328.283__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_26.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_335.667__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_32.786__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_32.306__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_213.73__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_120.311__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_327.961__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_271.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_329.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_327.214__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_331.977__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_259.265__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_31.717__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_136.053__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_329.555__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_329.754__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_331.291__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_330.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_327.329__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_31.342__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_332.727__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_240.004__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_141.683__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_32.517__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_119.073__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_152.343__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_28.709__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6676
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6676/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_331.979__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_330.659__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_28.023__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_87.604__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_283.075__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_216.698__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_327.483__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_197.973__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_110.312__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_230.005__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_327.238__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_248.117__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_17.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_29.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_231.243__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_30.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_241.301__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_32.736__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_99.126__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_251.19__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_27.273__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_29.341__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_248.099__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_32.039__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_100.758__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_126.498__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_206.875__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_133.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_203.916__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_318.974__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_24.333__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_32.762__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_327.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_327.23__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_136.586__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_214.263__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_109.015__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_333.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_146.4__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_79.122__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_301.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_327.264__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_102.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_223.818__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_32.671__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_327.694__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_30.246__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_31.603__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_262.712__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_208.633__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_49.119__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_32.381__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_67.271__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_102.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_30.445__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_32.77__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_143.441__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_342.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_328.397__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_28.021__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_328.283__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_26.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_335.667__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_32.786__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_32.306__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_213.73__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_120.311__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_327.961__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_271.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_329.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_327.214__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_331.977__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_259.265__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_31.717__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_136.053__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_329.555__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_329.754__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_331.291__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_330.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_327.329__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_31.342__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_332.727__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_240.004__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_141.683__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_32.517__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_119.073__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_152.343__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_28.709__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_2924
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_2924/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_331.979__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_330.659__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_28.023__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_87.604__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_283.075__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_216.698__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_327.483__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_197.973__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_110.312__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_230.005__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_327.238__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_248.117__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_17.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_29.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_231.243__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_30.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_241.301__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_32.736__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_99.126__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_251.19__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_27.273__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_29.341__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_248.099__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_32.039__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_100.758__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_126.498__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_206.875__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_133.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_203.916__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_318.974__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_24.333__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_32.762__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_327.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_327.23__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_136.586__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_214.263__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_109.015__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_333.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_146.4__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_79.122__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_301.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_327.264__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_102.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_223.818__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_32.671__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_327.694__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_30.246__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_31.603__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_262.712__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_208.633__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_49.119__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_32.381__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_67.271__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_102.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_30.445__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_32.77__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_143.441__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_342.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_328.397__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_28.021__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_328.283__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_26.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_335.667__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_32.786__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_32.306__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_213.73__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_120.311__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_327.961__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_271.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_329.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_327.214__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_331.977__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_259.265__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_31.717__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_136.053__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_329.555__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_329.754__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_331.291__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_330.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_327.329__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_31.342__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_332.727__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_240.004__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_141.683__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_32.517__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_119.073__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_152.343__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_28.709__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_2276
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_2276/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_331.979__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_330.659__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_28.023__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_87.604__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_283.075__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_216.698__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_327.483__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_197.973__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_110.312__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_230.005__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_327.238__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_248.117__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_17.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_29.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_231.243__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_30.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_241.301__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_32.736__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_99.126__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_251.19__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_27.273__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_29.341__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_248.099__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_32.039__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_100.758__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_126.498__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_206.875__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_133.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_203.916__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_318.974__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_24.333__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_32.762__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_327.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_327.23__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_136.586__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_214.263__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_109.015__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_333.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_146.4__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_79.122__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_301.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_327.264__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_102.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_223.818__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_32.671__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_327.694__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_30.246__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_31.603__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_262.712__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_208.633__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_49.119__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_32.381__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_67.271__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_102.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_30.445__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_32.77__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_143.441__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_342.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_328.397__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_28.021__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_328.283__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_26.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_335.667__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_32.786__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_32.306__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_213.73__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_120.311__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_327.961__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_271.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_329.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_327.214__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_331.977__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_259.265__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_31.717__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_136.053__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_329.555__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_329.754__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_331.291__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_330.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_327.329__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_31.342__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_332.727__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_240.004__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_141.683__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_32.517__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_119.073__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_152.343__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_28.709__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_6166
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_6166/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_331.979__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_330.659__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_28.023__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_87.604__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_283.075__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_216.698__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_327.483__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_197.973__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_110.312__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_230.005__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_327.238__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_248.117__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_17.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_29.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_231.243__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_30.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_241.301__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_32.736__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_99.126__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_251.19__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_27.273__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_29.341__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_248.099__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_32.039__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_100.758__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_126.498__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_206.875__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_133.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_203.916__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_318.974__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_24.333__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_32.762__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_327.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_327.23__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_136.586__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_214.263__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_109.015__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_333.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_146.4__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_79.122__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_301.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_327.264__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_102.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_223.818__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_32.671__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_327.694__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_30.246__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_31.603__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_262.712__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_208.633__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_49.119__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_32.381__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_67.271__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_102.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_30.445__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_32.77__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_143.441__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_342.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_328.397__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_28.021__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_328.283__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_26.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_335.667__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_32.786__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_32.306__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_213.73__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_120.311__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_327.961__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_271.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_329.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_327.214__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_331.977__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_259.265__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_31.717__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_136.053__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_329.555__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_329.754__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_331.291__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_330.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_327.329__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_31.342__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_332.727__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_240.004__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_141.683__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_32.517__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_119.073__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_152.343__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_28.709__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_931
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_931/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_331.979__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_330.659__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_28.023__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_87.604__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_283.075__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_216.698__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_327.483__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_197.973__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_110.312__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_230.005__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_327.238__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_248.117__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_17.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_29.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_231.243__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_30.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_241.301__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_32.736__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_99.126__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_251.19__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_27.273__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_29.341__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_248.099__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_32.039__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_100.758__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_126.498__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_206.875__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_133.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_203.916__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_318.974__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_24.333__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_32.762__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_327.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_327.23__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_136.586__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_214.263__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_109.015__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_333.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_146.4__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_79.122__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_301.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_327.264__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_102.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_223.818__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_32.671__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_327.694__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_30.246__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_31.603__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_262.712__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_208.633__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_49.119__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_32.381__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_67.271__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_102.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_30.445__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_32.77__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_143.441__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_342.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_328.397__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_28.021__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_328.283__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_26.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_335.667__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_32.786__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_32.306__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_213.73__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_120.311__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_327.961__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_271.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_329.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_327.214__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_331.977__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_259.265__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_31.717__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_136.053__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_329.555__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_329.754__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_331.291__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_330.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_327.329__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_31.342__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_332.727__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_240.004__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_141.683__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_32.517__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_119.073__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_152.343__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_28.709__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_3476
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_3476/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_331.979__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_330.659__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_28.023__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_87.604__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_283.075__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_216.698__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_327.483__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_197.973__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_110.312__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_230.005__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_327.238__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_248.117__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_17.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_29.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_231.243__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_30.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_241.301__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_32.736__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_99.126__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_251.19__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_27.273__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_29.341__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_248.099__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_32.039__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_100.758__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_126.498__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_206.875__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_133.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_203.916__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_318.974__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_24.333__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_32.762__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_327.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_327.23__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_136.586__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_214.263__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_109.015__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_333.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_146.4__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_79.122__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_301.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_327.264__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_102.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_223.818__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_32.671__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_327.694__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_30.246__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_31.603__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_262.712__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_208.633__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_49.119__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_32.381__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_67.271__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_102.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_30.445__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_32.77__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_143.441__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_342.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_328.397__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_28.021__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_328.283__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_26.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_335.667__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_32.786__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_32.306__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_213.73__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_120.311__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_327.961__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_271.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_329.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_327.214__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_331.977__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_259.265__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_31.717__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_136.053__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_329.555__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_329.754__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_331.291__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_330.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_327.329__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_31.342__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_332.727__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_240.004__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_141.683__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_32.517__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_119.073__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_152.343__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_28.709__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_4822
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_4822/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_331.979__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_330.659__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_28.023__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_87.604__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_283.075__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_216.698__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_327.483__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_197.973__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_110.312__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_230.005__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_327.238__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_248.117__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_17.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_29.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_231.243__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_30.92__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_241.301__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_32.736__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_99.126__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_251.19__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_27.273__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_70.732_az_29.341__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_248.099__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_32.039__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.976_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_328.656__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_100.758__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_126.498__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_206.875__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_133.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_203.916__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_318.974__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_24.333__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_57.995_az_32.762__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_327.619__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_327.23__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_136.586__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_214.263__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_109.015__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_333.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_146.4__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_79.122__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_301.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.25_az_327.264__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_10.0_az_102.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.528_az_223.818__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_32.671__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_327.694__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_90__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_30.246__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_31.603__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_262.712__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_208.633__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_49.119__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_14.984_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.41_az_32.381__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_67.271__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_102.217__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_30.445__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_55.944_az_32.77__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_143.441__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_35.904_az_342.538__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_355.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_49.458_az_328.397__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_73.142_az_28.021__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_328.283__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_37.814_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.522_az_26.462__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_39.646_az_335.667__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_32.786__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_61.965_az_32.306__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_213.73__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.197_az_120.311__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_63.255_az_327.961__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_82.155_az_271.199__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_67.045_az_329.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_56.633_az_327.214__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_43.113_az_331.977__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_23.630_az_259.265__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_64.533_az_31.717__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_136.053__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.284_az_329.555__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_46.37_az_329.754__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_331.291__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_69.512_az_330.08__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_59.336_az_327.329__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_75.226_az_31.342__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_74.336_az_332.727__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_240.004__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_65.796_az_31.344__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_141.683__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_60.66_az_32.517__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_68.068_az_119.073__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_52.374_az_152.343__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_47.952_az_270__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_71.94_az_28.709__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240131_allsky_v0.10.5_all_dec_base/TestingDataset/dl1_20240131_allsky_v0.10.5_all_dec_base_node_theta_32.059_az_175.158__merged.h5
+    path_model: 
+      /fefs/aswg/data/models/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/dec_min_1802
+    output: 
+      /fefs/aswg/data/mc/DL2/AllSky/20240219_allsky_v0.10.7_all_dec_srcdep_base/TestingDataset/dec_min_1802/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB


### PR DESCRIPTION
<!---  
You may leave this message, it will be commented out in your PR.
- if you are requesting a new config to be processed, please use the New Prod Config template
- if you are proposing changes to lstmcpipe library delete the template and describe your PR as usual
--->

<!---  
New Prod Config template
Add Prod_ID and fill the template
Your Pull Request must include the following files placed in directory `production_configs/prod_id`:
- lstmcpipe config file
- lstchain config
- readme.md

Add label `new_prod_config`
---> 

# New Prod config

Self check-list:

- [x] I have checked the lstchain config, in particular for:
  - [ ] `az_tel` instead of `sin_az_tel` if data to be analyzed have been produced with lstchain <= v0.9.7
  - [ ] "increase_nsb" and "increase_psf" are provided in "image_modifier" (if used)
- [x] I have checked the environment in the lstmcpipe config and it is the one used to analyse DL>1 data
- [x] I have provided the command (in README), or script (in additionnal .py file) used to produce the lstmcpipe config

## Prod_ID
20240219_allsky_v0.10.7_all_dec_srcdep_base production

## Short description of the config
Base production for all declinations lines with lstchain v0.10.7 & source-dependent approach
This production includes only training step and DL1 to DL2 step with existing training/test DL1 data

## Why this config is needed 
