### PR TITLE
add --source_prod_id as arg to generate config

### DIFF
--- a/lstmcpipe/scripts/lstmcpipe_generate_config.py
+++ b/lstmcpipe/scripts/lstmcpipe_generate_config.py
@@ -68,7 +68,19 @@ def build_argparser():
         default=None,
     )
 
-    parser.add_argument("--dec_list", nargs="+", help="Use only with AllSkyFull prods", default=None)
+    parser.add_argument(
+        "--dec_list",
+        nargs="+",
+        help="Use only with AllSkyFull prods",
+        default=None,
+    )
+
+    parser.add_argument(
+        "--source_prod_id",
+        type=str,
+        help="Use only with prods starting from an existing source prod",
+        default=None,
+    )
 
     parser.add_argument(
         "--kwargs",
@@ -93,6 +105,8 @@ def main():
     kwargs = {}
     if args.dec_list:
         kwargs.update({"dec_list": args.dec_list})
+    if args.source_prod_id:
+        kwargs.update({"source_prod_id": args.source_prod_id})
     if args.kwargs:
         kwargs.update(args.kwargs)
 


### PR DESCRIPTION
fixes #290 by introducing `--source_prod_id` for DL1ab type prods
Adding this arg should be less confusing to users.