### PR TITLE
Fix prod 20240122_v0.10.4_prod5_trans_80 config

### DIFF
--- a/production_configs/20240122_v0.10.4_prod5_trans_80/lstchain_config_2024-01-22.json
+++ b/production_configs/20240122_v0.10.4_prod5_trans_80/lstchain_config_2024-01-22.json
@@ -4,7 +4,8 @@
             "allowed_tels": [
                 1
             ],
-            "max_events": null
+            "max_events": null,
+            "focal_length_choice": "EQUIVALENT"
         },
         "LSTEventSource": {
             "default_trigger_type": "ucts",


### PR DESCRIPTION
prod5 MC files need the config to set  "focal_length_choice": "EQUIVALENT" to be analyzed with lstchain v0.10

