### PR TITLE
Update versions of actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,12 +14,12 @@ jobs:
         python-version: ['3.9', '3.10', '3.11']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -63,7 +63,7 @@ jobs:
             conda activate ci
             pytest --cov=lstmcpipe --cov-report=xml lstmcpipe
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
 
       - name: Detect added configs
         uses: tj-actions/changed-files@v39


### PR DESCRIPTION
There seems to be a problem with codecov step, something related to the repository token `Please upload with the Codecov repository upload token to resolve issue` says in the logs.

I see that the version of codecov is outdated:it was using v1, (current latest version is v4). This may also help solving the problem