### PR TITLE
add configs for prod 20240716_v0.10.7_src10_dec3476_tuned

### DIFF
--- a/production_configs/20240716_v0.10.7_src10_dec3476_tuned/README.md
+++ b/production_configs/20240716_v0.10.7_src10_dec3476_tuned/README.md
@@ -1,0 +1,25 @@
+# Product Configuration for src10
+
+## Prod_ID
+
+20240716_v0.10.7_src10_dec3476_tuned
+
+##  Description
+
+Config for reprocessing of Gamma Diffuse MC at declination line of 34.76 deg, based on 20240430_v0.10.4_src9_dec3476_tuned.
+
+NSB tuning adapted to the observed data of src10.
+
+## Objective
+
+Need diffuse MC with tuning for new source: src10
+
+## Config file creation
+
+The config file was initially cretaed by using lstmcpipe_generate_config:
+'''
+lstmcpipe_generate_config PathConfigAllSkyFullDL1ab  --dec_list dec_3476 --prod_id 20240716_v0.10.7_src10_dec3476_tuned --kwargs source_prod_id=20240430_v0.10.4_src9_dec3476_tuned
+'''
+
+Added image_modifier to tune NSB to src10.
+Manually edited to split dataset similar as 20240430_v0.10.4_src9_dec3476_tuned.

--- a/production_configs/20240716_v0.10.7_src10_dec3476_tuned/lstchain_config_2024-07-16.json
+++ b/production_configs/20240716_v0.10.7_src10_dec3476_tuned/lstchain_config_2024-07-16.json
@@ -1,0 +1,322 @@
+{
+    "source_config": {
+        "EventSource": {
+            "allowed_tels": [
+                1
+            ],
+            "max_events": null
+        },
+        "LSTEventSource": {
+            "default_trigger_type": "ucts",
+            "allowed_tels": [
+                1
+            ],
+            "min_flatfield_adc": 3000,
+            "min_flatfield_pixel_fraction": 0.8,
+            "calibrate_flatfields_and_pedestals": false,
+            "EventTimeCalculator": {
+                "dragon_reference_counter": null,
+                "dragon_reference_time": null
+            },
+            "PointingSource": {
+                "drive_report_path": null
+            },
+            "LSTR0Corrections": {
+                "calib_scale_high_gain": 1.088,
+                "calib_scale_low_gain": 1.004,
+                "drs4_pedestal_path": null,
+                "calibration_path": null,
+                "drs4_time_calibration_path": null
+            }
+        }
+    },
+    "events_filters": {
+        "intensity": [
+            0,
+            Infinity
+        ],
+        "width": [
+            0,
+            Infinity
+        ],
+        "length": [
+            0,
+            Infinity
+        ],
+        "wl": [
+            0,
+            Infinity
+        ],
+        "r": [
+            0,
+            Infinity
+        ],
+        "leakage_intensity_width_2": [
+            0,
+            Infinity
+        ]
+    },
+    "n_training_events": {
+        "gamma_regressors": 1.0,
+        "gamma_tmp_regressors": 0.8,
+        "gamma_classifier": 0.2,
+        "proton_classifier": 1.0
+    },
+    "tailcut": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "sigma": 2.5,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "dynamic_cleaning": {
+        "apply": true,
+        "threshold": 267,
+        "fraction_cleaning_intensity": 0.03
+    },
+    "random_forest_energy_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": 1.0,
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "warm_start": false
+    },
+    "random_forest_disp_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": 1.0,
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "warm_start": false
+    },
+    "random_forest_disp_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": 1.0,
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "random_forest_particle_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": 1.0,
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "energy_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2",
+        "sin_az_tel",
+        "alt_tel"
+    ],
+    "disp_method": "disp_norm_sign",
+    "disp_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2",
+        "sin_az_tel",
+        "alt_tel"
+    ],
+    "disp_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2",
+        "sin_az_tel",
+        "alt_tel"
+    ],
+    "particle_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "signed_skewness",
+        "kurtosis",
+        "signed_time_gradient",
+        "leakage_intensity_width_2",
+        "log_reco_energy",
+        "reco_disp_norm",
+        "reco_disp_sign",
+        "sin_az_tel",
+        "alt_tel"
+    ],
+    "allowed_tels": [
+        1
+    ],
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+        "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "timestamps_pointing": "ucts",
+    "train_gamma_src_r_deg": [
+        0,
+        Infinity
+    ],
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+    "volume_reducer": {
+        "algorithm": null,
+        "parameters": {}
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+    "LSTCalibrationCalculator": {
+        "systematic_correction_path": null,
+        "npe_median_cut_outliers": [
+            -5,
+            5
+        ],
+        "squared_excess_noise_factor": 1.222,
+        "flatfield_product": "FlasherFlatFieldCalculator",
+        "pedestal_product": "PedestalIntegrator",
+        "PedestalIntegrator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_median_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_product": "FixedWindowSum",
+            "FixedWindowSum": {
+                "window_shift": 6,
+                "window_width": 12,
+                "peak_index": 18,
+                "apply_integration_correction": false
+            }
+        },
+        "FlasherFlatFieldCalculator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_product": "LocalPeakWindowSum",
+            "charge_median_cut_outliers": [
+                -0.9,
+                2
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "time_cut_outliers": [
+                2,
+                38
+            ],
+            "LocalPeakWindowSum": {
+                "window_shift": 5,
+                "window_width": 12,
+                "apply_integration_correction": false
+            }
+        }
+    },
+    "waveform_nsb_tuning": {
+        "nsb_tuning": false,
+        "nsb_tuning_ratio": 0.52,
+        "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    },
+    "write_interleaved_events": {
+        "DataWriter": {
+            "overwrite": true,
+            "write_images": false,
+            "write_parameters": false,
+            "write_waveforms": true,
+            "transform_waveform": true,
+            "waveform_dtype": "uint16",
+            "waveform_offset": 400,
+            "waveform_scale": 80
+        }
+    },
+    "image_modifier": {
+      "increase_nsb": true,
+      "extra_noise_in_dim_pixels": 1.327,
+      "extra_bias_in_dim_pixels": 0.41,
+      "transition_charge": 8,
+      "extra_noise_in_bright_pixels": 0.0
+    }
+}

--- a/production_configs/20240716_v0.10.7_src10_dec3476_tuned/lstmcpipe_config_2024-07-16_PathConfigAllSkyFullDL1ab.yaml
+++ b/production_configs/20240716_v0.10.7_src10_dec3476_tuned/lstmcpipe_config_2024-07-16_PathConfigAllSkyFullDL1ab.yaml
@@ -1,0 +1,439 @@
+# lstmcpipe generated config from PathConfigAllSkyFullDL1ab - 2024-07-16
+
+workflow_kind: lstchain
+
+# prod_id ex: local_no_n_islands. Default; v00 (if key left empty or None)
+prod_id: 20240716_v0.10.7_src10_dec3476_tuned
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.10.7
+
+slurm_config:
+# dpps is the default account for lstanalyzer - other users should use aswg
+  user_account: dpps
+lstmcpipe_version: 0.10.4
+prod_type: PathConfigAllSkyFullDL1ab
+stages_to_run:
+- dl1ab
+- train_test_split
+- merge_dl1
+- train_pipe
+- dl1_to_dl2
+
+stages:
+  dl1ab:
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_60.505_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_60.505_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_299.495_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_299.495_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_63.197_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_63.197_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_296.803_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_296.803_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_65.502_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_65.502_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_294.498_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_294.498_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_67.397_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_67.397_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_292.603_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_292.603_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_68.802_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_68.802_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_291.198_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_291.198_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_69.537_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_69.537_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_290.463_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_290.463_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_69.19_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_69.19_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_290.81_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_290.81_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_66.706_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_66.706_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_293.294_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_293.294_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_58.737_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_58.737_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_301.263_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_301.263_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_7.093_az_31.09_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_7.093_az_31.09_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_69.992_az_60.505_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_69.992_az_60.505_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_69.992_az_299.495_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_69.992_az_299.495_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_63.108_az_63.197_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_63.108_az_63.197_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_63.108_az_296.803_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_63.108_az_296.803_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_56.069_az_65.502_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_56.069_az_65.502_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_56.069_az_294.498_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_56.069_az_294.498_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_48.911_az_67.397_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_48.911_az_67.397_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_48.911_az_292.603_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_48.911_az_292.603_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_41.666_az_68.802_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_41.666_az_68.802_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_41.666_az_291.198_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_41.666_az_291.198_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_34.367_az_69.537_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_34.367_az_69.537_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_34.367_az_290.463_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_34.367_az_290.463_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_27.055_az_69.19_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_27.055_az_69.19_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_27.055_az_290.81_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_27.055_az_290.81_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_19.807_az_66.706_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_19.807_az_66.706_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_19.807_az_293.294_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_19.807_az_293.294_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_12.829_az_58.737_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_12.829_az_58.737_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_12.829_az_301.263_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_12.829_az_301.263_
+  - input: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240430_v0.10.4_src9_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_7.093_az_31.09_
+    output: 
+      /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/node_corsika_theta_7.093_az_31.09_
+  train_test_split:
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_60.505_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_60.505_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_60.505_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_299.495_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_299.495_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_299.495_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_63.197_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_63.197_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_63.197_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_296.803_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_296.803_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_296.803_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_65.502_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_65.502_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_65.502_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_294.498_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_294.498_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_294.498_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_67.397_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_67.397_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_67.397_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_292.603_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_292.603_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_292.603_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_68.802_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_68.802_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_68.802_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_291.198_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_291.198_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_291.198_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_69.537_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_69.537_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_69.537_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_290.463_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_290.463_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_290.463_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_69.19_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_69.19_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_69.19_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_290.81_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_290.81_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_290.81_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_66.706_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_66.706_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_66.706_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_293.294_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_293.294_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_293.294_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_58.737_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_58.737_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_58.737_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_301.263_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_301.263_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_301.263_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_7.093_az_31.09_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_7.093_az_31.09_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_7.093_az_31.09_
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_7.093_az_328.91_
+    output:
+      test: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_7.093_az_328.91_
+      train: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/node_corsika_theta_7.093_az_328.91_
+  merge_dl1:
+  - extra_slurm_options:
+      partition: long
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse
+    options: --pattern */*.h5 --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/dl1_20240716_v0.10.7_src10_dec3476_tuned_dec_3476_GammaDiffuse_merged.h5
+  - extra_slurm_options:
+      partition: long
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons
+    options: --pattern */*.h5 --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/dl1_20240716_v0.10.7_src10_dec3476_tuned_dec_3476_Protons_merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_60.505_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_60.505__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_299.495_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_299.495__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_63.197_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_63.197__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_296.803_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_296.803__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_65.502_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_65.502__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_294.498_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_294.498__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_67.397_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_67.397__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_292.603_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_292.603__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_68.802_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_68.802__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_291.198_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_291.198__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_69.537_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_69.537__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_290.463_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_290.463__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_69.19_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_69.19__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_290.81_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_290.81__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_66.706_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_66.706__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_293.294_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_293.294__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_58.737_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_58.737__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_301.263_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_301.263__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_7.093_az_31.09_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_7.093_az_31.09__merged.h5
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_7.093_az_328.91_
+    options: --no-image
+    output: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_7.093_az_328.91__merged.h5
+  train_pipe:
+  - extra_slurm_options:
+      cpus-per-task: 16
+      mem: 100G
+      partition: xxl
+    input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TrainingDataset/dec_3476/GammaDiffuse/dl1_20240716_v0.10.7_src10_dec3476_tuned_dec_3476_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TrainingDataset/dec_3476/Protons/dl1_20240716_v0.10.7_src10_dec3476_tuned_dec_3476_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  dl1_to_dl2:
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_60.505__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_69.992_az_60.505_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_69.992_az_299.495__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_69.992_az_299.495_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_63.197__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_63.108_az_63.197_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_63.108_az_296.803__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_63.108_az_296.803_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_65.502__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_56.069_az_65.502_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_56.069_az_294.498__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_56.069_az_294.498_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_67.397__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_48.911_az_67.397_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_48.911_az_292.603__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_48.911_az_292.603_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_68.802__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_41.666_az_68.802_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_41.666_az_291.198__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_41.666_az_291.198_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_69.537__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_34.367_az_69.537_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_34.367_az_290.463__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_34.367_az_290.463_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_69.19__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_27.055_az_69.19_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_27.055_az_290.81__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_27.055_az_290.81_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_66.706__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_19.807_az_66.706_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_19.807_az_293.294__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_19.807_az_293.294_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_58.737__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_12.829_az_58.737_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_12.829_az_301.263__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_12.829_az_301.263_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_7.093_az_31.09__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_7.093_az_31.09_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476
+  - extra_slurm_options:
+      mem: 60GB
+    input: /fefs/aswg/data/mc/DL1/AllSky/20240716_v0.10.7_src10_dec3476_tuned/Split_TestDataset/dec_3476/GammaDiffuse/node_corsika_theta_7.093_az_328.91__merged.h5
+    output: /fefs/aswg/data/mc/DL2/AllSky/20240716_v0.10.7_src10_dec3476_tuned/TestingDataset/dec_3476/node_corsika_theta_7.093_az_328.91_
+    path_model: /fefs/aswg/data/models/AllSky/20240716_v0.10.7_src10_dec3476_tuned/dec_3476


### PR DESCRIPTION
<!---  
You may leave this message, it will be commented out in your PR.
- if you are requesting a new config to be processed, please use the New Prod Config template
- if you are proposing changes to lstmcpipe library delete the template and describe your PR as usual
--->

<!---  
New Prod Config template
Add Prod_ID and fill the template
Your Pull Request must include the following files placed in directory `production_configs/prod_id`:
- lstmcpipe config file
- lstchain config
- readme.md

Add label `new_prod_config`
---> 

# New Prod config

Self check-list:

- [ ] I have checked the lstchain config, in particular for:
  - [ ] `az_tel` instead of `sin_az_tel` if data to be analyzed have been produced with lstchain <= v0.9.7
  - [ ] "increase_nsb" and "increase_psf" are provided in "image_modifier" (if used)
- [ ] I have checked the environment in the lstmcpipe config and it is the one used to analyse DL>1 data
- [ ] I have provided the command (in README), or script (in additionnal .py file) used to produce the lstmcpipe config

## Prod_ID

20240716_v0.10.7_src10_dec3476_tuned

## Short description of the config

Config for reprocessing of Gamma Diffuse MC at declination line of 34.76 deg, based on 20240430_v0.10.4_src9$
NSB tuning adapted to the observed data of src10.

## Why this config is needed 

Need diffuse MC with tuning for new source: src10
