### PR TITLE
20250601 retrain

### DIFF
--- a/lstmcpipe/config/pipeline_config.py
+++ b/lstmcpipe/config/pipeline_config.py
@@ -45,6 +45,28 @@ def load_config(config_path):
     return config
 
 
+def _stage_validator(stage_config, stage_name=None):
+    """
+    Validate the stage configuration.
+
+    Parameters:
+    -----------
+    stage_config: dict
+        Dictionary with the stage configuration
+
+    Returns:
+    --------
+    True if the stage configuration is valid
+    """
+    for ii, step in enumerate(stage_config):
+        if 'input' not in step:
+            raise ValueError(f"The 'input' key is missing in the step {ii} of stage {stage_name}.")
+        if 'output' not in step:
+            raise ValueError(f"The 'output' key is missing in the step {ii} of stage {stage_name}.")
+    print(f"Stage {stage_name} configuration is valid.")
+    return True
+
+
 def config_valid(loaded_config):
     """
     Test if the given dictionary contains valid values for the
@@ -89,6 +111,13 @@ def config_valid(loaded_config):
     for stage in stages_to_run:
         if stage not in loaded_config['stages']:
             raise KeyError(f"Missing paths for stage {stage} provided in stages_to_run")
+
+    for stage_name, stage_config in loaded_config['stages'].items():
+        if stage_name not in stages_to_run:
+            log.warning(f"Stage {stage_name} is not in stages_to_run, it will be ignored.")
+            continue
+        if not _stage_validator(stage_config, stage_name=stage_name):
+            raise ValueError(f"Invalid configuration for stage {stage_name}")
 
     dl1_noise_tune_data_run = loaded_config.get("dl1_noise_tune_data_run")
     dl1_noise_tune_mc_run = loaded_config.get("dl1_noise_tune_mc_run")

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.00/lstchain_config_2025-07-01.json
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.00/lstchain_config_2025-07-01.json
@@ -1,0 +1,295 @@
+{
+    "source_config": {
+        "EventSource": {
+            "allowed_tels": [
+                1
+            ],
+            "max_events": null
+        },
+        "LSTEventSource": {
+            "default_trigger_type": "ucts",
+            "allowed_tels": [
+                1
+            ],
+            "min_flatfield_adc": 3000,
+            "min_flatfield_pixel_fraction": 0.8,
+            "calibrate_flatfields_and_pedestals": false,
+            "EventTimeCalculator": {
+                "dragon_reference_counter": null,
+                "dragon_reference_time": null
+            },
+            "PointingSource": {
+                "drive_report_path": null
+            },
+            "LSTR0Corrections": {
+                "calib_scale_high_gain": 1.088,
+                "calib_scale_low_gain": 1.004,
+                "drs4_pedestal_path": null,
+                "calibration_path": null,
+                "drs4_time_calibration_path": null
+            }
+        }
+    },
+    "events_filters": {
+        "intensity": [
+            0,
+            Infinity
+        ],
+        "width": [
+            0,
+            Infinity
+        ],
+        "length": [
+            0,
+            Infinity
+        ],
+        "wl": [
+            0,
+            Infinity
+        ],
+        "r": [
+            0,
+            Infinity
+        ],
+        "leakage_intensity_width_2": [
+            0,
+            Infinity
+        ]
+    },
+    "n_training_events": {
+        "gamma_regressors": 1.0,
+        "gamma_tmp_regressors": 0.8,
+        "gamma_classifier": 0.2,
+        "proton_classifier": 1.0
+    },
+    "tailcut": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "sigma": 2.5,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "dynamic_cleaning": {
+        "apply": true,
+        "threshold": 267,
+        "fraction_cleaning_intensity": 0.03
+    },
+    "random_forest_energy_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "random_forest_particle_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "energy_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_method": "disp_norm_sign",
+    "disp_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "particle_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "signed_skewness",
+        "kurtosis",
+        "signed_time_gradient",
+        "leakage_intensity_width_2",
+        "log_reco_energy",
+        "reco_disp_norm",
+        "reco_disp_sign"
+    ],
+    "allowed_tels": [
+        1
+    ],
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+        "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "timestamps_pointing": "ucts",
+    "train_gamma_src_r_deg": [
+        0,
+        Infinity
+    ],
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+    "volume_reducer": {
+        "algorithm": null,
+        "parameters": {}
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+    "LSTCalibrationCalculator": {
+        "systematic_correction_path": null,
+        "squared_excess_noise_factor": 1.222,
+        "flatfield_product": "FlasherFlatFieldCalculator",
+        "pedestal_product": "PedestalIntegrator",
+        "PedestalIntegrator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_median_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_product": "FixedWindowSum",
+            "FixedWindowSum": {
+                "window_shift": 6,
+                "window_width": 12,
+                "peak_index": 18,
+                "apply_integration_correction": false
+            }
+        },
+        "FlasherFlatFieldCalculator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_product": "LocalPeakWindowSum",
+            "charge_median_cut_outliers": [
+                -0.5,
+                0.5
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "time_cut_outliers": [
+                2,
+                38
+            ],
+            "LocalPeakWindowSum": {
+                "window_shift": 5,
+                "window_width": 12,
+                "apply_integration_correction": false
+            }
+        }
+    },
+    "waveform_nsb_tuning": {
+        "nsb_tuning": false,
+        "nsb_tuning_ratio": 0.52,
+        "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    }
+}

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.00/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.00/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
@@ -1,0 +1,556 @@
+# lstmcpipe generated config from PathConfigAllTrainTestDL1b - 2025-07-01
+
+workflow_kind: lstchain
+
+# prod_id ex: local_no_n_islands. Default; v00 (if key left empty or None)
+prod_id: 20250601_v0.11.0_allsky_models_nsb_0.00
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.10.7
+
+slurm_config:
+# dpps is the default account for lstanalyzer - other users should use aswg
+  user_account: dpps
+lstmcpipe_version: 0.11.3
+prod_type: PathConfigAllTrainTestDL1b
+stages_to_run:
+- train_pipe
+- dl1_to_dl2
+stages:
+  train_pipe:
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TrainingDataset/GammaDiffuse/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_train_dec_2276_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TrainingDataset/Protons/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_train_dec_2276_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    extra_slurm_options:
+      partition: xxl
+      mem: 160G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  dl1_to_dl2:
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.00/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.00_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.00/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 80GB

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.07/lstchain_config_2025-07-01.json
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.07/lstchain_config_2025-07-01.json
@@ -1,0 +1,295 @@
+{
+    "source_config": {
+        "EventSource": {
+            "allowed_tels": [
+                1
+            ],
+            "max_events": null
+        },
+        "LSTEventSource": {
+            "default_trigger_type": "ucts",
+            "allowed_tels": [
+                1
+            ],
+            "min_flatfield_adc": 3000,
+            "min_flatfield_pixel_fraction": 0.8,
+            "calibrate_flatfields_and_pedestals": false,
+            "EventTimeCalculator": {
+                "dragon_reference_counter": null,
+                "dragon_reference_time": null
+            },
+            "PointingSource": {
+                "drive_report_path": null
+            },
+            "LSTR0Corrections": {
+                "calib_scale_high_gain": 1.088,
+                "calib_scale_low_gain": 1.004,
+                "drs4_pedestal_path": null,
+                "calibration_path": null,
+                "drs4_time_calibration_path": null
+            }
+        }
+    },
+    "events_filters": {
+        "intensity": [
+            0,
+            Infinity
+        ],
+        "width": [
+            0,
+            Infinity
+        ],
+        "length": [
+            0,
+            Infinity
+        ],
+        "wl": [
+            0,
+            Infinity
+        ],
+        "r": [
+            0,
+            Infinity
+        ],
+        "leakage_intensity_width_2": [
+            0,
+            Infinity
+        ]
+    },
+    "n_training_events": {
+        "gamma_regressors": 1.0,
+        "gamma_tmp_regressors": 0.8,
+        "gamma_classifier": 0.2,
+        "proton_classifier": 1.0
+    },
+    "tailcut": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "sigma": 2.5,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "dynamic_cleaning": {
+        "apply": true,
+        "threshold": 267,
+        "fraction_cleaning_intensity": 0.03
+    },
+    "random_forest_energy_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "random_forest_particle_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "energy_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_method": "disp_norm_sign",
+    "disp_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "particle_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "signed_skewness",
+        "kurtosis",
+        "signed_time_gradient",
+        "leakage_intensity_width_2",
+        "log_reco_energy",
+        "reco_disp_norm",
+        "reco_disp_sign"
+    ],
+    "allowed_tels": [
+        1
+    ],
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+        "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "timestamps_pointing": "ucts",
+    "train_gamma_src_r_deg": [
+        0,
+        Infinity
+    ],
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+    "volume_reducer": {
+        "algorithm": null,
+        "parameters": {}
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+    "LSTCalibrationCalculator": {
+        "systematic_correction_path": null,
+        "squared_excess_noise_factor": 1.222,
+        "flatfield_product": "FlasherFlatFieldCalculator",
+        "pedestal_product": "PedestalIntegrator",
+        "PedestalIntegrator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_median_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_product": "FixedWindowSum",
+            "FixedWindowSum": {
+                "window_shift": 6,
+                "window_width": 12,
+                "peak_index": 18,
+                "apply_integration_correction": false
+            }
+        },
+        "FlasherFlatFieldCalculator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_product": "LocalPeakWindowSum",
+            "charge_median_cut_outliers": [
+                -0.5,
+                0.5
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "time_cut_outliers": [
+                2,
+                38
+            ],
+            "LocalPeakWindowSum": {
+                "window_shift": 5,
+                "window_width": 12,
+                "apply_integration_correction": false
+            }
+        }
+    },
+    "waveform_nsb_tuning": {
+        "nsb_tuning": false,
+        "nsb_tuning_ratio": 0.52,
+        "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    }
+}

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.07/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.07/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
@@ -1,0 +1,4828 @@
+# lstmcpipe generated config from PathConfigAllTrainTestDL1b - 2025-07-01
+
+workflow_kind: lstchain
+
+# prod_id ex: local_no_n_islands. Default; v00 (if key left empty or None)
+prod_id: 20250601_v0.11.0_allsky_models_nsb_0.07
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.10.7
+
+slurm_config:
+# dpps is the default account for lstanalyzer - other users should use aswg
+  user_account: dpps
+lstmcpipe_version: 0.11.3
+prod_type: PathConfigAllTrainTestDL1b
+stages_to_run:
+- train_pipe
+- dl1_to_dl2
+stages:
+  train_pipe:
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/GammaDiffuse/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_min_413_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/Protons/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_min_413_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/GammaDiffuse/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_min_2924_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/Protons/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_min_2924_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/GammaDiffuse/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_931_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/Protons/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_931_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/GammaDiffuse/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_6676_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/Protons/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_6676_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/GammaDiffuse/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_3476_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/Protons/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_3476_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/GammaDiffuse/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_4822_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/Protons/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_4822_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/GammaDiffuse/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_6166_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/Protons/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_6166_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/GammaDiffuse/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_min_1802_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/Protons/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_min_1802_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/GammaDiffuse/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_2276_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TrainingDataset/Protons/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_train_dec_2276_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    extra_slurm_options:
+      partition: xxl
+      mem: 160G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  dl1_to_dl2:
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_931/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.07/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.07_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.07/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 80GB

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.14/lstchain_config_2025-07-01.json
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.14/lstchain_config_2025-07-01.json
@@ -1,0 +1,295 @@
+{
+    "source_config": {
+        "EventSource": {
+            "allowed_tels": [
+                1
+            ],
+            "max_events": null
+        },
+        "LSTEventSource": {
+            "default_trigger_type": "ucts",
+            "allowed_tels": [
+                1
+            ],
+            "min_flatfield_adc": 3000,
+            "min_flatfield_pixel_fraction": 0.8,
+            "calibrate_flatfields_and_pedestals": false,
+            "EventTimeCalculator": {
+                "dragon_reference_counter": null,
+                "dragon_reference_time": null
+            },
+            "PointingSource": {
+                "drive_report_path": null
+            },
+            "LSTR0Corrections": {
+                "calib_scale_high_gain": 1.088,
+                "calib_scale_low_gain": 1.004,
+                "drs4_pedestal_path": null,
+                "calibration_path": null,
+                "drs4_time_calibration_path": null
+            }
+        }
+    },
+    "events_filters": {
+        "intensity": [
+            0,
+            Infinity
+        ],
+        "width": [
+            0,
+            Infinity
+        ],
+        "length": [
+            0,
+            Infinity
+        ],
+        "wl": [
+            0,
+            Infinity
+        ],
+        "r": [
+            0,
+            Infinity
+        ],
+        "leakage_intensity_width_2": [
+            0,
+            Infinity
+        ]
+    },
+    "n_training_events": {
+        "gamma_regressors": 1.0,
+        "gamma_tmp_regressors": 0.8,
+        "gamma_classifier": 0.2,
+        "proton_classifier": 1.0
+    },
+    "tailcut": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "sigma": 2.5,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "dynamic_cleaning": {
+        "apply": true,
+        "threshold": 267,
+        "fraction_cleaning_intensity": 0.03
+    },
+    "random_forest_energy_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "random_forest_particle_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "energy_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_method": "disp_norm_sign",
+    "disp_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "particle_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "signed_skewness",
+        "kurtosis",
+        "signed_time_gradient",
+        "leakage_intensity_width_2",
+        "log_reco_energy",
+        "reco_disp_norm",
+        "reco_disp_sign"
+    ],
+    "allowed_tels": [
+        1
+    ],
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+        "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "timestamps_pointing": "ucts",
+    "train_gamma_src_r_deg": [
+        0,
+        Infinity
+    ],
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+    "volume_reducer": {
+        "algorithm": null,
+        "parameters": {}
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+    "LSTCalibrationCalculator": {
+        "systematic_correction_path": null,
+        "squared_excess_noise_factor": 1.222,
+        "flatfield_product": "FlasherFlatFieldCalculator",
+        "pedestal_product": "PedestalIntegrator",
+        "PedestalIntegrator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_median_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_product": "FixedWindowSum",
+            "FixedWindowSum": {
+                "window_shift": 6,
+                "window_width": 12,
+                "peak_index": 18,
+                "apply_integration_correction": false
+            }
+        },
+        "FlasherFlatFieldCalculator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_product": "LocalPeakWindowSum",
+            "charge_median_cut_outliers": [
+                -0.5,
+                0.5
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "time_cut_outliers": [
+                2,
+                38
+            ],
+            "LocalPeakWindowSum": {
+                "window_shift": 5,
+                "window_width": 12,
+                "apply_integration_correction": false
+            }
+        }
+    },
+    "waveform_nsb_tuning": {
+        "nsb_tuning": false,
+        "nsb_tuning_ratio": 0.52,
+        "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    }
+}

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.14/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.14/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
@@ -1,0 +1,4828 @@
+# lstmcpipe generated config from PathConfigAllTrainTestDL1b - 2025-07-01
+
+workflow_kind: lstchain
+
+# prod_id ex: local_no_n_islands. Default; v00 (if key left empty or None)
+prod_id: 20250601_v0.11.0_allsky_models_nsb_0.14
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.10.7
+
+slurm_config:
+# dpps is the default account for lstanalyzer - other users should use aswg
+  user_account: dpps
+lstmcpipe_version: 0.11.3
+prod_type: PathConfigAllTrainTestDL1b
+stages_to_run:
+- train_pipe
+- dl1_to_dl2
+stages:
+  train_pipe:
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/GammaDiffuse/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_min_1802_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/Protons/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_min_1802_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/GammaDiffuse/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_6166_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/Protons/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_6166_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/GammaDiffuse/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_3476_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/Protons/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_3476_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/GammaDiffuse/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_4822_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/Protons/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_4822_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/GammaDiffuse/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_931_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/Protons/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_931_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/GammaDiffuse/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_min_413_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/Protons/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_min_413_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/GammaDiffuse/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_6676_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/Protons/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_6676_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/GammaDiffuse/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_min_2924_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/Protons/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_min_2924_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/GammaDiffuse/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_2276_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TrainingDataset/Protons/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_train_dec_2276_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    extra_slurm_options:
+      partition: xxl
+      mem: 160G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  dl1_to_dl2:
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_931/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.14/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.14_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.14/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 80GB

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.22/lstchain_config_2025-07-01.json
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.22/lstchain_config_2025-07-01.json
@@ -1,0 +1,295 @@
+{
+    "source_config": {
+        "EventSource": {
+            "allowed_tels": [
+                1
+            ],
+            "max_events": null
+        },
+        "LSTEventSource": {
+            "default_trigger_type": "ucts",
+            "allowed_tels": [
+                1
+            ],
+            "min_flatfield_adc": 3000,
+            "min_flatfield_pixel_fraction": 0.8,
+            "calibrate_flatfields_and_pedestals": false,
+            "EventTimeCalculator": {
+                "dragon_reference_counter": null,
+                "dragon_reference_time": null
+            },
+            "PointingSource": {
+                "drive_report_path": null
+            },
+            "LSTR0Corrections": {
+                "calib_scale_high_gain": 1.088,
+                "calib_scale_low_gain": 1.004,
+                "drs4_pedestal_path": null,
+                "calibration_path": null,
+                "drs4_time_calibration_path": null
+            }
+        }
+    },
+    "events_filters": {
+        "intensity": [
+            0,
+            Infinity
+        ],
+        "width": [
+            0,
+            Infinity
+        ],
+        "length": [
+            0,
+            Infinity
+        ],
+        "wl": [
+            0,
+            Infinity
+        ],
+        "r": [
+            0,
+            Infinity
+        ],
+        "leakage_intensity_width_2": [
+            0,
+            Infinity
+        ]
+    },
+    "n_training_events": {
+        "gamma_regressors": 1.0,
+        "gamma_tmp_regressors": 0.8,
+        "gamma_classifier": 0.2,
+        "proton_classifier": 1.0
+    },
+    "tailcut": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "sigma": 2.5,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "dynamic_cleaning": {
+        "apply": true,
+        "threshold": 267,
+        "fraction_cleaning_intensity": 0.03
+    },
+    "random_forest_energy_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "random_forest_particle_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "energy_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_method": "disp_norm_sign",
+    "disp_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "particle_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "signed_skewness",
+        "kurtosis",
+        "signed_time_gradient",
+        "leakage_intensity_width_2",
+        "log_reco_energy",
+        "reco_disp_norm",
+        "reco_disp_sign"
+    ],
+    "allowed_tels": [
+        1
+    ],
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+        "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "timestamps_pointing": "ucts",
+    "train_gamma_src_r_deg": [
+        0,
+        Infinity
+    ],
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+    "volume_reducer": {
+        "algorithm": null,
+        "parameters": {}
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+    "LSTCalibrationCalculator": {
+        "systematic_correction_path": null,
+        "squared_excess_noise_factor": 1.222,
+        "flatfield_product": "FlasherFlatFieldCalculator",
+        "pedestal_product": "PedestalIntegrator",
+        "PedestalIntegrator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_median_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_product": "FixedWindowSum",
+            "FixedWindowSum": {
+                "window_shift": 6,
+                "window_width": 12,
+                "peak_index": 18,
+                "apply_integration_correction": false
+            }
+        },
+        "FlasherFlatFieldCalculator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_product": "LocalPeakWindowSum",
+            "charge_median_cut_outliers": [
+                -0.5,
+                0.5
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "time_cut_outliers": [
+                2,
+                38
+            ],
+            "LocalPeakWindowSum": {
+                "window_shift": 5,
+                "window_width": 12,
+                "apply_integration_correction": false
+            }
+        }
+    },
+    "waveform_nsb_tuning": {
+        "nsb_tuning": false,
+        "nsb_tuning_ratio": 0.52,
+        "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    }
+}

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.22/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.22/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
@@ -1,0 +1,4828 @@
+# lstmcpipe generated config from PathConfigAllTrainTestDL1b - 2025-07-01
+
+workflow_kind: lstchain
+
+# prod_id ex: local_no_n_islands. Default; v00 (if key left empty or None)
+prod_id: 20250601_v0.11.0_allsky_models_nsb_0.22
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.10.7
+
+slurm_config:
+# dpps is the default account for lstanalyzer - other users should use aswg
+  user_account: dpps
+lstmcpipe_version: 0.11.3
+prod_type: PathConfigAllTrainTestDL1b
+stages_to_run:
+- train_pipe
+- dl1_to_dl2
+stages:
+  train_pipe:
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/GammaDiffuse/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_min_2924_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/Protons/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_min_2924_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/GammaDiffuse/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_6676_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/Protons/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_6676_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/GammaDiffuse/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_3476_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/Protons/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_3476_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/GammaDiffuse/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_931_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/Protons/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_931_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/GammaDiffuse/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_6166_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/Protons/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_6166_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/GammaDiffuse/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_4822_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/Protons/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_4822_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/GammaDiffuse/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_min_1802_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/Protons/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_min_1802_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/GammaDiffuse/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_2276_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/Protons/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_2276_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    extra_slurm_options:
+      partition: xxl
+      mem: 160G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/GammaDiffuse/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_min_413_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TrainingDataset/Protons/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_train_dec_min_413_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  dl1_to_dl2:
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_931/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.22/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.22_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.22/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.38/lstchain_config_2025-07-01.json
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.38/lstchain_config_2025-07-01.json
@@ -1,0 +1,295 @@
+{
+    "source_config": {
+        "EventSource": {
+            "allowed_tels": [
+                1
+            ],
+            "max_events": null
+        },
+        "LSTEventSource": {
+            "default_trigger_type": "ucts",
+            "allowed_tels": [
+                1
+            ],
+            "min_flatfield_adc": 3000,
+            "min_flatfield_pixel_fraction": 0.8,
+            "calibrate_flatfields_and_pedestals": false,
+            "EventTimeCalculator": {
+                "dragon_reference_counter": null,
+                "dragon_reference_time": null
+            },
+            "PointingSource": {
+                "drive_report_path": null
+            },
+            "LSTR0Corrections": {
+                "calib_scale_high_gain": 1.088,
+                "calib_scale_low_gain": 1.004,
+                "drs4_pedestal_path": null,
+                "calibration_path": null,
+                "drs4_time_calibration_path": null
+            }
+        }
+    },
+    "events_filters": {
+        "intensity": [
+            0,
+            Infinity
+        ],
+        "width": [
+            0,
+            Infinity
+        ],
+        "length": [
+            0,
+            Infinity
+        ],
+        "wl": [
+            0,
+            Infinity
+        ],
+        "r": [
+            0,
+            Infinity
+        ],
+        "leakage_intensity_width_2": [
+            0,
+            Infinity
+        ]
+    },
+    "n_training_events": {
+        "gamma_regressors": 1.0,
+        "gamma_tmp_regressors": 0.8,
+        "gamma_classifier": 0.2,
+        "proton_classifier": 1.0
+    },
+    "tailcut": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "sigma": 2.5,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "dynamic_cleaning": {
+        "apply": true,
+        "threshold": 267,
+        "fraction_cleaning_intensity": 0.03
+    },
+    "random_forest_energy_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "random_forest_particle_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "energy_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_method": "disp_norm_sign",
+    "disp_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "particle_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "signed_skewness",
+        "kurtosis",
+        "signed_time_gradient",
+        "leakage_intensity_width_2",
+        "log_reco_energy",
+        "reco_disp_norm",
+        "reco_disp_sign"
+    ],
+    "allowed_tels": [
+        1
+    ],
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+        "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "timestamps_pointing": "ucts",
+    "train_gamma_src_r_deg": [
+        0,
+        Infinity
+    ],
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+    "volume_reducer": {
+        "algorithm": null,
+        "parameters": {}
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+    "LSTCalibrationCalculator": {
+        "systematic_correction_path": null,
+        "squared_excess_noise_factor": 1.222,
+        "flatfield_product": "FlasherFlatFieldCalculator",
+        "pedestal_product": "PedestalIntegrator",
+        "PedestalIntegrator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_median_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_product": "FixedWindowSum",
+            "FixedWindowSum": {
+                "window_shift": 6,
+                "window_width": 12,
+                "peak_index": 18,
+                "apply_integration_correction": false
+            }
+        },
+        "FlasherFlatFieldCalculator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_product": "LocalPeakWindowSum",
+            "charge_median_cut_outliers": [
+                -0.5,
+                0.5
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "time_cut_outliers": [
+                2,
+                38
+            ],
+            "LocalPeakWindowSum": {
+                "window_shift": 5,
+                "window_width": 12,
+                "apply_integration_correction": false
+            }
+        }
+    },
+    "waveform_nsb_tuning": {
+        "nsb_tuning": false,
+        "nsb_tuning_ratio": 0.52,
+        "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    }
+}

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.38/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.38/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
@@ -1,0 +1,4828 @@
+# lstmcpipe generated config from PathConfigAllTrainTestDL1b - 2025-07-01
+
+workflow_kind: lstchain
+
+# prod_id ex: local_no_n_islands. Default; v00 (if key left empty or None)
+prod_id: 20250601_v0.11.0_allsky_models_nsb_0.38
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.10.7
+
+slurm_config:
+# dpps is the default account for lstanalyzer - other users should use aswg
+  user_account: dpps
+lstmcpipe_version: 0.11.3
+prod_type: PathConfigAllTrainTestDL1b
+stages_to_run:
+- train_pipe
+- dl1_to_dl2
+stages:
+  train_pipe:
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/GammaDiffuse/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_931_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/Protons/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_931_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/GammaDiffuse/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_6166_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/Protons/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_6166_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/GammaDiffuse/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_6676_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/Protons/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_6676_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/GammaDiffuse/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_3476_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/Protons/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_3476_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/GammaDiffuse/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_min_1802_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/Protons/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_min_1802_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/GammaDiffuse/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_2276_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/Protons/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_2276_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    extra_slurm_options:
+      partition: xxl
+      mem: 160G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/GammaDiffuse/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_min_413_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/Protons/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_min_413_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/GammaDiffuse/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_min_2924_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/Protons/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_min_2924_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/GammaDiffuse/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_4822_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TrainingDataset/Protons/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_train_dec_4822_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  dl1_to_dl2:
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_931/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.38/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.38_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.38/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.50/lstchain_config_2025-07-01.json
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.50/lstchain_config_2025-07-01.json
@@ -1,0 +1,295 @@
+{
+    "source_config": {
+        "EventSource": {
+            "allowed_tels": [
+                1
+            ],
+            "max_events": null
+        },
+        "LSTEventSource": {
+            "default_trigger_type": "ucts",
+            "allowed_tels": [
+                1
+            ],
+            "min_flatfield_adc": 3000,
+            "min_flatfield_pixel_fraction": 0.8,
+            "calibrate_flatfields_and_pedestals": false,
+            "EventTimeCalculator": {
+                "dragon_reference_counter": null,
+                "dragon_reference_time": null
+            },
+            "PointingSource": {
+                "drive_report_path": null
+            },
+            "LSTR0Corrections": {
+                "calib_scale_high_gain": 1.088,
+                "calib_scale_low_gain": 1.004,
+                "drs4_pedestal_path": null,
+                "calibration_path": null,
+                "drs4_time_calibration_path": null
+            }
+        }
+    },
+    "events_filters": {
+        "intensity": [
+            0,
+            Infinity
+        ],
+        "width": [
+            0,
+            Infinity
+        ],
+        "length": [
+            0,
+            Infinity
+        ],
+        "wl": [
+            0,
+            Infinity
+        ],
+        "r": [
+            0,
+            Infinity
+        ],
+        "leakage_intensity_width_2": [
+            0,
+            Infinity
+        ]
+    },
+    "n_training_events": {
+        "gamma_regressors": 1.0,
+        "gamma_tmp_regressors": 0.8,
+        "gamma_classifier": 0.2,
+        "proton_classifier": 1.0
+    },
+    "tailcut": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "sigma": 2.5,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "dynamic_cleaning": {
+        "apply": true,
+        "threshold": 267,
+        "fraction_cleaning_intensity": 0.03
+    },
+    "random_forest_energy_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "random_forest_particle_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "energy_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_method": "disp_norm_sign",
+    "disp_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "particle_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "signed_skewness",
+        "kurtosis",
+        "signed_time_gradient",
+        "leakage_intensity_width_2",
+        "log_reco_energy",
+        "reco_disp_norm",
+        "reco_disp_sign"
+    ],
+    "allowed_tels": [
+        1
+    ],
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+        "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "timestamps_pointing": "ucts",
+    "train_gamma_src_r_deg": [
+        0,
+        Infinity
+    ],
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+    "volume_reducer": {
+        "algorithm": null,
+        "parameters": {}
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+    "LSTCalibrationCalculator": {
+        "systematic_correction_path": null,
+        "squared_excess_noise_factor": 1.222,
+        "flatfield_product": "FlasherFlatFieldCalculator",
+        "pedestal_product": "PedestalIntegrator",
+        "PedestalIntegrator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_median_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_product": "FixedWindowSum",
+            "FixedWindowSum": {
+                "window_shift": 6,
+                "window_width": 12,
+                "peak_index": 18,
+                "apply_integration_correction": false
+            }
+        },
+        "FlasherFlatFieldCalculator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_product": "LocalPeakWindowSum",
+            "charge_median_cut_outliers": [
+                -0.5,
+                0.5
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "time_cut_outliers": [
+                2,
+                38
+            ],
+            "LocalPeakWindowSum": {
+                "window_shift": 5,
+                "window_width": 12,
+                "apply_integration_correction": false
+            }
+        }
+    },
+    "waveform_nsb_tuning": {
+        "nsb_tuning": false,
+        "nsb_tuning_ratio": 0.52,
+        "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    }
+}

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.50/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.50/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
@@ -1,0 +1,4828 @@
+# lstmcpipe generated config from PathConfigAllTrainTestDL1b - 2025-07-01
+
+workflow_kind: lstchain
+
+# prod_id ex: local_no_n_islands. Default; v00 (if key left empty or None)
+prod_id: 20250601_v0.11.0_allsky_models_nsb_0.50
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.10.7
+
+slurm_config:
+# dpps is the default account for lstanalyzer - other users should use aswg
+  user_account: dpps
+lstmcpipe_version: 0.11.3
+prod_type: PathConfigAllTrainTestDL1b
+stages_to_run:
+- train_pipe
+- dl1_to_dl2
+stages:
+  train_pipe:
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/GammaDiffuse/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_6166_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/Protons/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_6166_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/GammaDiffuse/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_min_1802_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/Protons/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_min_1802_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/GammaDiffuse/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_4822_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/Protons/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_4822_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/GammaDiffuse/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_2276_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/Protons/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_2276_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    extra_slurm_options:
+      partition: xxl
+      mem: 160G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/GammaDiffuse/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_6676_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/Protons/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_6676_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/GammaDiffuse/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_3476_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/Protons/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_3476_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/GammaDiffuse/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_931_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/Protons/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_931_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/GammaDiffuse/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_min_2924_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/Protons/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_min_2924_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/GammaDiffuse/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_min_413_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TrainingDataset/Protons/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_train_dec_min_413_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  dl1_to_dl2:
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_931/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.50/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.50_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.50/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.81/lstchain_config_2025-07-01.json
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.81/lstchain_config_2025-07-01.json
@@ -1,0 +1,295 @@
+{
+    "source_config": {
+        "EventSource": {
+            "allowed_tels": [
+                1
+            ],
+            "max_events": null
+        },
+        "LSTEventSource": {
+            "default_trigger_type": "ucts",
+            "allowed_tels": [
+                1
+            ],
+            "min_flatfield_adc": 3000,
+            "min_flatfield_pixel_fraction": 0.8,
+            "calibrate_flatfields_and_pedestals": false,
+            "EventTimeCalculator": {
+                "dragon_reference_counter": null,
+                "dragon_reference_time": null
+            },
+            "PointingSource": {
+                "drive_report_path": null
+            },
+            "LSTR0Corrections": {
+                "calib_scale_high_gain": 1.088,
+                "calib_scale_low_gain": 1.004,
+                "drs4_pedestal_path": null,
+                "calibration_path": null,
+                "drs4_time_calibration_path": null
+            }
+        }
+    },
+    "events_filters": {
+        "intensity": [
+            0,
+            Infinity
+        ],
+        "width": [
+            0,
+            Infinity
+        ],
+        "length": [
+            0,
+            Infinity
+        ],
+        "wl": [
+            0,
+            Infinity
+        ],
+        "r": [
+            0,
+            Infinity
+        ],
+        "leakage_intensity_width_2": [
+            0,
+            Infinity
+        ]
+    },
+    "n_training_events": {
+        "gamma_regressors": 1.0,
+        "gamma_tmp_regressors": 0.8,
+        "gamma_classifier": 0.2,
+        "proton_classifier": 1.0
+    },
+    "tailcut": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "sigma": 2.5,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "dynamic_cleaning": {
+        "apply": true,
+        "threshold": 267,
+        "fraction_cleaning_intensity": 0.03
+    },
+    "random_forest_energy_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "random_forest_particle_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "energy_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_method": "disp_norm_sign",
+    "disp_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "particle_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "signed_skewness",
+        "kurtosis",
+        "signed_time_gradient",
+        "leakage_intensity_width_2",
+        "log_reco_energy",
+        "reco_disp_norm",
+        "reco_disp_sign"
+    ],
+    "allowed_tels": [
+        1
+    ],
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+        "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "timestamps_pointing": "ucts",
+    "train_gamma_src_r_deg": [
+        0,
+        Infinity
+    ],
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+    "volume_reducer": {
+        "algorithm": null,
+        "parameters": {}
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+    "LSTCalibrationCalculator": {
+        "systematic_correction_path": null,
+        "squared_excess_noise_factor": 1.222,
+        "flatfield_product": "FlasherFlatFieldCalculator",
+        "pedestal_product": "PedestalIntegrator",
+        "PedestalIntegrator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_median_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_product": "FixedWindowSum",
+            "FixedWindowSum": {
+                "window_shift": 6,
+                "window_width": 12,
+                "peak_index": 18,
+                "apply_integration_correction": false
+            }
+        },
+        "FlasherFlatFieldCalculator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_product": "LocalPeakWindowSum",
+            "charge_median_cut_outliers": [
+                -0.5,
+                0.5
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "time_cut_outliers": [
+                2,
+                38
+            ],
+            "LocalPeakWindowSum": {
+                "window_shift": 5,
+                "window_width": 12,
+                "apply_integration_correction": false
+            }
+        }
+    },
+    "waveform_nsb_tuning": {
+        "nsb_tuning": false,
+        "nsb_tuning_ratio": 0.52,
+        "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    }
+}

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.81/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-0.81/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
@@ -1,0 +1,4828 @@
+# lstmcpipe generated config from PathConfigAllTrainTestDL1b - 2025-07-01
+
+workflow_kind: lstchain
+
+# prod_id ex: local_no_n_islands. Default; v00 (if key left empty or None)
+prod_id: 20250601_v0.11.0_allsky_models_nsb_0.81
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.10.7
+
+slurm_config:
+# dpps is the default account for lstanalyzer - other users should use aswg
+  user_account: dpps
+lstmcpipe_version: 0.11.3
+prod_type: PathConfigAllTrainTestDL1b
+stages_to_run:
+- train_pipe
+- dl1_to_dl2
+stages:
+  train_pipe:
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/GammaDiffuse/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_2276_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/Protons/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_2276_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    extra_slurm_options:
+      partition: xxl
+      mem: 160G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/GammaDiffuse/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_3476_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/Protons/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_3476_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/GammaDiffuse/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_931_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/Protons/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_931_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/GammaDiffuse/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_min_2924_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/Protons/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_min_2924_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/GammaDiffuse/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_6166_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/Protons/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_6166_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/GammaDiffuse/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_4822_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/Protons/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_4822_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/GammaDiffuse/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_min_413_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/Protons/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_min_413_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/GammaDiffuse/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_min_1802_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/Protons/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_min_1802_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/GammaDiffuse/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_6676_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TrainingDataset/Protons/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_train_dec_6676_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  dl1_to_dl2:
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_931/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_0.81/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_0.81_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_0.81/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-1.25/lstchain_config_2025-07-01.json
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-1.25/lstchain_config_2025-07-01.json
@@ -1,0 +1,295 @@
+{
+    "source_config": {
+        "EventSource": {
+            "allowed_tels": [
+                1
+            ],
+            "max_events": null
+        },
+        "LSTEventSource": {
+            "default_trigger_type": "ucts",
+            "allowed_tels": [
+                1
+            ],
+            "min_flatfield_adc": 3000,
+            "min_flatfield_pixel_fraction": 0.8,
+            "calibrate_flatfields_and_pedestals": false,
+            "EventTimeCalculator": {
+                "dragon_reference_counter": null,
+                "dragon_reference_time": null
+            },
+            "PointingSource": {
+                "drive_report_path": null
+            },
+            "LSTR0Corrections": {
+                "calib_scale_high_gain": 1.088,
+                "calib_scale_low_gain": 1.004,
+                "drs4_pedestal_path": null,
+                "calibration_path": null,
+                "drs4_time_calibration_path": null
+            }
+        }
+    },
+    "events_filters": {
+        "intensity": [
+            0,
+            Infinity
+        ],
+        "width": [
+            0,
+            Infinity
+        ],
+        "length": [
+            0,
+            Infinity
+        ],
+        "wl": [
+            0,
+            Infinity
+        ],
+        "r": [
+            0,
+            Infinity
+        ],
+        "leakage_intensity_width_2": [
+            0,
+            Infinity
+        ]
+    },
+    "n_training_events": {
+        "gamma_regressors": 1.0,
+        "gamma_tmp_regressors": 0.8,
+        "gamma_classifier": 0.2,
+        "proton_classifier": 1.0
+    },
+    "tailcut": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "sigma": 2.5,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "dynamic_cleaning": {
+        "apply": true,
+        "threshold": 267,
+        "fraction_cleaning_intensity": 0.03
+    },
+    "random_forest_energy_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "random_forest_particle_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "energy_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_method": "disp_norm_sign",
+    "disp_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "particle_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "signed_skewness",
+        "kurtosis",
+        "signed_time_gradient",
+        "leakage_intensity_width_2",
+        "log_reco_energy",
+        "reco_disp_norm",
+        "reco_disp_sign"
+    ],
+    "allowed_tels": [
+        1
+    ],
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+        "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "timestamps_pointing": "ucts",
+    "train_gamma_src_r_deg": [
+        0,
+        Infinity
+    ],
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+    "volume_reducer": {
+        "algorithm": null,
+        "parameters": {}
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+    "LSTCalibrationCalculator": {
+        "systematic_correction_path": null,
+        "squared_excess_noise_factor": 1.222,
+        "flatfield_product": "FlasherFlatFieldCalculator",
+        "pedestal_product": "PedestalIntegrator",
+        "PedestalIntegrator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_median_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_product": "FixedWindowSum",
+            "FixedWindowSum": {
+                "window_shift": 6,
+                "window_width": 12,
+                "peak_index": 18,
+                "apply_integration_correction": false
+            }
+        },
+        "FlasherFlatFieldCalculator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_product": "LocalPeakWindowSum",
+            "charge_median_cut_outliers": [
+                -0.5,
+                0.5
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "time_cut_outliers": [
+                2,
+                38
+            ],
+            "LocalPeakWindowSum": {
+                "window_shift": 5,
+                "window_width": 12,
+                "apply_integration_correction": false
+            }
+        }
+    },
+    "waveform_nsb_tuning": {
+        "nsb_tuning": false,
+        "nsb_tuning_ratio": 0.52,
+        "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    }
+}

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-1.25/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-1.25/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
@@ -1,0 +1,4828 @@
+# lstmcpipe generated config from PathConfigAllTrainTestDL1b - 2025-07-01
+
+workflow_kind: lstchain
+
+# prod_id ex: local_no_n_islands. Default; v00 (if key left empty or None)
+prod_id: 20250601_v0.11.0_allsky_models_nsb_1.25
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.10.7
+
+slurm_config:
+# dpps is the default account for lstanalyzer - other users should use aswg
+  user_account: dpps
+lstmcpipe_version: 0.11.3
+prod_type: PathConfigAllTrainTestDL1b
+stages_to_run:
+- train_pipe
+- dl1_to_dl2
+stages:
+  train_pipe:
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/GammaDiffuse/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_931_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/Protons/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_931_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/GammaDiffuse/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_2276_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/Protons/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_2276_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    extra_slurm_options:
+      partition: xxl
+      mem: 160G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/GammaDiffuse/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_3476_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/Protons/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_3476_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/GammaDiffuse/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_6166_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/Protons/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_6166_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/GammaDiffuse/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_6676_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/Protons/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_6676_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/GammaDiffuse/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_4822_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/Protons/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_4822_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/GammaDiffuse/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_min_2924_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/Protons/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_min_2924_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/GammaDiffuse/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_min_413_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/Protons/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_min_413_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/GammaDiffuse/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_min_1802_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TrainingDataset/Protons/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_train_dec_min_1802_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  dl1_to_dl2:
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_931/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.25/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.25_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.25/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-1.76/lstchain_config_2025-07-01.json
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-1.76/lstchain_config_2025-07-01.json
@@ -1,0 +1,295 @@
+{
+    "source_config": {
+        "EventSource": {
+            "allowed_tels": [
+                1
+            ],
+            "max_events": null
+        },
+        "LSTEventSource": {
+            "default_trigger_type": "ucts",
+            "allowed_tels": [
+                1
+            ],
+            "min_flatfield_adc": 3000,
+            "min_flatfield_pixel_fraction": 0.8,
+            "calibrate_flatfields_and_pedestals": false,
+            "EventTimeCalculator": {
+                "dragon_reference_counter": null,
+                "dragon_reference_time": null
+            },
+            "PointingSource": {
+                "drive_report_path": null
+            },
+            "LSTR0Corrections": {
+                "calib_scale_high_gain": 1.088,
+                "calib_scale_low_gain": 1.004,
+                "drs4_pedestal_path": null,
+                "calibration_path": null,
+                "drs4_time_calibration_path": null
+            }
+        }
+    },
+    "events_filters": {
+        "intensity": [
+            0,
+            Infinity
+        ],
+        "width": [
+            0,
+            Infinity
+        ],
+        "length": [
+            0,
+            Infinity
+        ],
+        "wl": [
+            0,
+            Infinity
+        ],
+        "r": [
+            0,
+            Infinity
+        ],
+        "leakage_intensity_width_2": [
+            0,
+            Infinity
+        ]
+    },
+    "n_training_events": {
+        "gamma_regressors": 1.0,
+        "gamma_tmp_regressors": 0.8,
+        "gamma_classifier": 0.2,
+        "proton_classifier": 1.0
+    },
+    "tailcut": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "sigma": 2.5,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "dynamic_cleaning": {
+        "apply": true,
+        "threshold": 267,
+        "fraction_cleaning_intensity": 0.03
+    },
+    "random_forest_energy_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "random_forest_particle_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "energy_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_method": "disp_norm_sign",
+    "disp_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "particle_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "signed_skewness",
+        "kurtosis",
+        "signed_time_gradient",
+        "leakage_intensity_width_2",
+        "log_reco_energy",
+        "reco_disp_norm",
+        "reco_disp_sign"
+    ],
+    "allowed_tels": [
+        1
+    ],
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+        "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "timestamps_pointing": "ucts",
+    "train_gamma_src_r_deg": [
+        0,
+        Infinity
+    ],
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+    "volume_reducer": {
+        "algorithm": null,
+        "parameters": {}
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+    "LSTCalibrationCalculator": {
+        "systematic_correction_path": null,
+        "squared_excess_noise_factor": 1.222,
+        "flatfield_product": "FlasherFlatFieldCalculator",
+        "pedestal_product": "PedestalIntegrator",
+        "PedestalIntegrator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_median_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_product": "FixedWindowSum",
+            "FixedWindowSum": {
+                "window_shift": 6,
+                "window_width": 12,
+                "peak_index": 18,
+                "apply_integration_correction": false
+            }
+        },
+        "FlasherFlatFieldCalculator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_product": "LocalPeakWindowSum",
+            "charge_median_cut_outliers": [
+                -0.5,
+                0.5
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "time_cut_outliers": [
+                2,
+                38
+            ],
+            "LocalPeakWindowSum": {
+                "window_shift": 5,
+                "window_width": 12,
+                "apply_integration_correction": false
+            }
+        }
+    },
+    "waveform_nsb_tuning": {
+        "nsb_tuning": false,
+        "nsb_tuning_ratio": 0.52,
+        "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    }
+}

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-1.76/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-1.76/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
@@ -1,0 +1,4828 @@
+# lstmcpipe generated config from PathConfigAllTrainTestDL1b - 2025-07-01
+
+workflow_kind: lstchain
+
+# prod_id ex: local_no_n_islands. Default; v00 (if key left empty or None)
+prod_id: 20250601_v0.11.0_allsky_models_nsb_1.76
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.10.7
+
+slurm_config:
+# dpps is the default account for lstanalyzer - other users should use aswg
+  user_account: dpps
+lstmcpipe_version: 0.11.3
+prod_type: PathConfigAllTrainTestDL1b
+stages_to_run:
+- train_pipe
+- dl1_to_dl2
+stages:
+  train_pipe:
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/GammaDiffuse/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_6676_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/Protons/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_6676_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/GammaDiffuse/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_min_413_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/Protons/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_min_413_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/GammaDiffuse/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_2276_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/Protons/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_2276_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    extra_slurm_options:
+      partition: xxl
+      mem: 160G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/GammaDiffuse/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_6166_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/Protons/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_6166_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/GammaDiffuse/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_min_1802_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/Protons/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_min_1802_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/GammaDiffuse/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_4822_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/Protons/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_4822_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/GammaDiffuse/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_931_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/Protons/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_931_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/GammaDiffuse/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_min_2924_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/Protons/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_min_2924_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/GammaDiffuse/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_3476_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TrainingDataset/Protons/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_train_dec_3476_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  dl1_to_dl2:
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_931/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_1.76/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_1.76_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_1.76/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-2.34/lstchain_config_2025-07-01.json
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-2.34/lstchain_config_2025-07-01.json
@@ -1,0 +1,295 @@
+{
+    "source_config": {
+        "EventSource": {
+            "allowed_tels": [
+                1
+            ],
+            "max_events": null
+        },
+        "LSTEventSource": {
+            "default_trigger_type": "ucts",
+            "allowed_tels": [
+                1
+            ],
+            "min_flatfield_adc": 3000,
+            "min_flatfield_pixel_fraction": 0.8,
+            "calibrate_flatfields_and_pedestals": false,
+            "EventTimeCalculator": {
+                "dragon_reference_counter": null,
+                "dragon_reference_time": null
+            },
+            "PointingSource": {
+                "drive_report_path": null
+            },
+            "LSTR0Corrections": {
+                "calib_scale_high_gain": 1.088,
+                "calib_scale_low_gain": 1.004,
+                "drs4_pedestal_path": null,
+                "calibration_path": null,
+                "drs4_time_calibration_path": null
+            }
+        }
+    },
+    "events_filters": {
+        "intensity": [
+            0,
+            Infinity
+        ],
+        "width": [
+            0,
+            Infinity
+        ],
+        "length": [
+            0,
+            Infinity
+        ],
+        "wl": [
+            0,
+            Infinity
+        ],
+        "r": [
+            0,
+            Infinity
+        ],
+        "leakage_intensity_width_2": [
+            0,
+            Infinity
+        ]
+    },
+    "n_training_events": {
+        "gamma_regressors": 1.0,
+        "gamma_tmp_regressors": 0.8,
+        "gamma_classifier": 0.2,
+        "proton_classifier": 1.0
+    },
+    "tailcut": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "tailcuts_clean_with_pedestal_threshold": {
+        "picture_thresh": 8,
+        "boundary_thresh": 4,
+        "sigma": 2.5,
+        "keep_isolated_pixels": false,
+        "min_number_picture_neighbors": 2,
+        "use_only_main_island": false,
+        "delta_time": 2
+    },
+    "dynamic_cleaning": {
+        "apply": true,
+        "threshold": 267,
+        "fraction_cleaning_intensity": 0.03
+    },
+    "random_forest_energy_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_regressor_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 150,
+        "bootstrap": true,
+        "criterion": "squared_error",
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0,
+        "warm_start": false
+    },
+    "random_forest_disp_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "random_forest_particle_classifier_args": {
+        "max_depth": 30,
+        "min_samples_leaf": 10,
+        "n_jobs": -1,
+        "n_estimators": 100,
+        "criterion": "gini",
+        "min_samples_split": 10,
+        "min_weight_fraction_leaf": 0.0,
+        "max_features": "auto",
+        "max_leaf_nodes": null,
+        "min_impurity_decrease": 0.0,
+        "bootstrap": true,
+        "oob_score": false,
+        "random_state": 42,
+        "verbose": 0.0,
+        "warm_start": false,
+        "class_weight": null
+    },
+    "energy_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_method": "disp_norm_sign",
+    "disp_regression_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "disp_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "wl",
+        "skewness",
+        "kurtosis",
+        "time_gradient",
+        "leakage_intensity_width_2"
+    ],
+    "particle_classification_features": [
+        "log_intensity",
+        "width",
+        "length",
+        "x",
+        "y",
+        "wl",
+        "signed_skewness",
+        "kurtosis",
+        "signed_time_gradient",
+        "leakage_intensity_width_2",
+        "log_reco_energy",
+        "reco_disp_norm",
+        "reco_disp_sign"
+    ],
+    "allowed_tels": [
+        1
+    ],
+    "write_pe_image": false,
+    "mc_image_scaling_factor": 1,
+    "image_extractor": "LocalPeakWindowSum",
+    "image_extractor_for_muons": "GlobalPeakWindowSum",
+    "CameraCalibrator": {
+        "apply_waveform_time_shift": false
+    },
+    "time_sampling_correction_path": "default",
+    "LocalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "GlobalPeakWindowSum": {
+        "window_shift": 4,
+        "window_width": 8,
+        "apply_integration_correction": true
+    },
+    "timestamps_pointing": "ucts",
+    "train_gamma_src_r_deg": [
+        0,
+        Infinity
+    ],
+    "source_dependent": false,
+    "mc_nominal_source_x_deg": 0.4,
+    "mc_nominal_source_y_deg": 0.0,
+    "volume_reducer": {
+        "algorithm": null,
+        "parameters": {}
+    },
+    "calibration_product": "LSTCalibrationCalculator",
+    "LSTCalibrationCalculator": {
+        "systematic_correction_path": null,
+        "squared_excess_noise_factor": 1.222,
+        "flatfield_product": "FlasherFlatFieldCalculator",
+        "pedestal_product": "PedestalIntegrator",
+        "PedestalIntegrator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_median_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "charge_product": "FixedWindowSum",
+            "FixedWindowSum": {
+                "window_shift": 6,
+                "window_width": 12,
+                "peak_index": 18,
+                "apply_integration_correction": false
+            }
+        },
+        "FlasherFlatFieldCalculator": {
+            "sample_size": 10000,
+            "sample_duration": 100000,
+            "tel_id": 1,
+            "time_sampling_correction_path": null,
+            "charge_product": "LocalPeakWindowSum",
+            "charge_median_cut_outliers": [
+                -0.5,
+                0.5
+            ],
+            "charge_std_cut_outliers": [
+                -10,
+                10
+            ],
+            "time_cut_outliers": [
+                2,
+                38
+            ],
+            "LocalPeakWindowSum": {
+                "window_shift": 5,
+                "window_width": 12,
+                "apply_integration_correction": false
+            }
+        }
+    },
+    "waveform_nsb_tuning": {
+        "nsb_tuning": false,
+        "nsb_tuning_ratio": 0.52,
+        "spe_location": "lstchain/data/SinglePhE_ResponseInPhE_expo2Gaus.dat"
+    }
+}

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-2.34/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/NSB-2.34/lstmcpipe_config_2025-07-01_PathConfigAllTrainTestDL1b.yaml
@@ -1,0 +1,4828 @@
+# lstmcpipe generated config from PathConfigAllTrainTestDL1b - 2025-07-01
+
+workflow_kind: lstchain
+
+# prod_id ex: local_no_n_islands. Default; v00 (if key left empty or None)
+prod_id: 20250601_v0.11.0_allsky_models_nsb_2.34
+
+source_environment:
+  source_file: /fefs/aswg/software/conda/etc/profile.d/conda.sh
+  conda_env: lstchain-v0.10.7
+
+slurm_config:
+# dpps is the default account for lstanalyzer - other users should use aswg
+  user_account: dpps
+lstmcpipe_version: 0.11.3
+prod_type: PathConfigAllTrainTestDL1b
+stages_to_run:
+- train_pipe
+- dl1_to_dl2
+stages:
+  train_pipe:
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/GammaDiffuse/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_6676_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/Protons/dec_6676/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_6676_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/GammaDiffuse/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_6166_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/Protons/dec_6166/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_6166_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/GammaDiffuse/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_931_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/Protons/dec_931/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_931_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/GammaDiffuse/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_min_2924_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/Protons/dec_min_2924/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_min_2924_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/GammaDiffuse/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_2276_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/Protons/dec_2276/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_2276_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    extra_slurm_options:
+      partition: xxl
+      mem: 160G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/GammaDiffuse/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_3476_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/Protons/dec_3476/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_3476_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/GammaDiffuse/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_min_1802_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/Protons/dec_min_1802/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_min_1802_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/GammaDiffuse/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_4822_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/Protons/dec_4822/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_4822_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  - input:
+      gamma: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/GammaDiffuse/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_min_413_GammaDiffuse_merged.h5
+      proton: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TrainingDataset/Protons/dec_min_413/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_train_dec_min_413_Protons_merged.h5
+    output: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    extra_slurm_options:
+      partition: xxl
+      mem: 100G
+      cpus-per-task: 16
+      time: 03-00:00:00
+  dl1_to_dl2:
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6676
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6676/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_6166
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_6166/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_931
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_931/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_2924
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_2924/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_2276
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_2276/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 80GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_3476
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_3476/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_1802
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_1802/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_4822
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_4822/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_331.979__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_331.979_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_330.659__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_330.659_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_28.023__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_28.023_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_87.604__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_87.604_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_283.075__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_283.075_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_216.698__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_216.698_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_327.483__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_327.483_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_197.973__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_197.973_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_110.312__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_110.312_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_230.005__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_230.005_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_327.238__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_327.238_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_248.117__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_248.117_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_17.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_17.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_29.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_29.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_231.243__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_231.243_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_30.92__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_30.92_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_241.301__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_241.301_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_32.736__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_32.736_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_99.126__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_99.126_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_251.19__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_251.19_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_27.273__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_27.273_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_70.732_az_29.341__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_70.732_az_29.341_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_248.099__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_248.099_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_32.039__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_32.039_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.976_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_65.976_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_328.656__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_328.656_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_100.758__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_100.758_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_126.498__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_126.498_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_206.875__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_206.875_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_133.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_133.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_203.916__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_203.916_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_318.974__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_318.974_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_24.333__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_24.333_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_57.995_az_32.762__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_57.995_az_32.762_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_327.619__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_327.619_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_327.23__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_327.23_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_136.586__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_136.586_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_214.263__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_214.263_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_109.015__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_109.015_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_333.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_333.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_146.4__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_146.4_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_79.122__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_79.122_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_301.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_301.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.25_az_327.264__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_55.25_az_327.264_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_10.0_az_102.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_10.0_az_102.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.528_az_223.818__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_60.528_az_223.818_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_32.671__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_32.671_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_327.694__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_327.694_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_90__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_90_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_30.246__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_30.246_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_31.603__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_31.603_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_262.712__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_262.712_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_208.633__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_208.633_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_49.119__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_49.119_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_14.984_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_14.984_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.41_az_32.381__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_52.41_az_32.381_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_67.271__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_67.271_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_102.217__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_102.217_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_30.445__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_30.445_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_55.944_az_32.77__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_55.944_az_32.77_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_143.441__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_143.441_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_35.904_az_342.538__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_35.904_az_342.538_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_355.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_355.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_49.458_az_328.397__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_49.458_az_328.397_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_73.142_az_28.021__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_73.142_az_28.021_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_328.283__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_328.283_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_37.814_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_37.814_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.522_az_26.462__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_75.522_az_26.462_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_39.646_az_335.667__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_39.646_az_335.667_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_32.786__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_32.786_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_61.965_az_32.306__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_61.965_az_32.306_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_213.73__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_213.73_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.197_az_120.311__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_43.197_az_120.311_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_63.255_az_327.961__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_63.255_az_327.961_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_82.155_az_271.199__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_82.155_az_271.199_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_67.045_az_329.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_67.045_az_329.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_56.633_az_327.214__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_56.633_az_327.214_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_43.113_az_331.977__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_43.113_az_331.977_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_23.630_az_259.265__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_23.630_az_259.265_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_64.533_az_31.717__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_64.533_az_31.717_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_136.053__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_136.053_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.284_az_329.555__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_68.284_az_329.555_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_46.37_az_329.754__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_46.37_az_329.754_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_331.291__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_331.291_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_69.512_az_330.08__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_69.512_az_330.08_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_59.336_az_327.329__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_59.336_az_327.329_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_175.158_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_75.226_az_31.342__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_75.226_az_31.342_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_74.336_az_332.727__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_74.336_az_332.727_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_240.004__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_240.004_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_65.796_az_31.344__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_65.796_az_31.344_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_141.683__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_141.683_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_60.66_az_32.517__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_60.66_az_32.517_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_68.068_az_119.073__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_68.068_az_119.073_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_52.374_az_152.343__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_52.374_az_152.343_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_47.952_az_270__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_47.952_az_270_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_71.94_az_28.709__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_71.94_az_28.709_
+    extra_slurm_options:
+      mem: 60GB
+  - input: /fefs/aswg/data/mc/DL1/AllSky/20240918_v0.10.12_allsky_nsb_tuning_2.34/TestingDataset/Gamma/dl1_20240918_v0.10.12_allsky_nsb_tuning_2.34_Gamma_test_node_theta_32.059_az_175.158__merged.h5
+    path_model: /fefs/aswg/data/models/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/dec_min_413
+    output: /fefs/aswg/data/mc/DL2/AllSky/20250601_v0.11.0_allsky_models_nsb_2.34/TestingDataset/Gamma/dec_min_413/node_theta_32.059_az_175.158_
+    extra_slurm_options:
+      mem: 60GB

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/README.md
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/README.md
@@ -1,0 +1,13 @@
+# PROD 20250601_v0.11.0_allsky_nsb_grid_retrain_models
+
+This production is needed to retrain the models with lstchain v0.11.0 due to an incompatibility with the latest scikit-learn version.
+See issue https://github.com/cta-observatory/cta-lstchain/issues/1366 
+
+
+Here we only do the training and testing again.
+Configs generated with `make.sh`
+
+author: Thomas V.
+
+
+

--- a/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/make.sh
+++ b/production_configs/20250601_v0.11.0_allsky_nsb_grid_retrain_models/make.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Define the base production ID prefix
+BASE_PROD_ID_PREFIX="20240918_v0.10.12_allsky_nsb_tuning_"
+
+# List of NSB levels (the last 4 characters of the prod_id)
+NSB_LEVELS=(
+    "0.00"
+    "0.07"
+    "0.14"
+    "0.22"
+    "0.38"
+    "0.50"
+    "0.81"
+    "1.25"
+    "1.76"
+    "2.34"
+)
+
+
+# Define the common lstmcpipe_generate_config command parts
+DEC_LIST="dec_2276 dec_3476 dec_4822 dec_6166 dec_6676 dec_931 dec_min_1802 dec_min_2924 dec_min_413"
+LSTMCPIPE_COMMAND_BASE="lstmcpipe_generate_config PathConfigAllTrainTestDL1b --dec_list $DEC_LIST --prod_id 20250601_v0.11.0_allsky_models_nsb_X.XX --kwargs source_prod_id=PROD_ID --overwrite"
+
+# Loop through each NSB level
+for nsb_level in "${NSB_LEVELS[@]}"; do
+    # Construct the full prod_id for the current NSB level
+    current_prod_id="${BASE_PROD_ID_PREFIX}${nsb_level}"
+
+    # Construct the directory name
+    dir_name="NSB-${nsb_level}"
+
+    echo "Processing prod_id: ${current_prod_id}"
+    echo "Creating directory: ${dir_name}"
+
+    # Create the directory
+    mkdir -p "${dir_name}"
+
+    # Check if the directory was created successfully
+    if [ $? -ne 0 ]; then
+        echo "Error: Could not create directory ${dir_name}. Skipping this NSB level."
+        continue
+    fi
+
+    # Go inside the directory
+    pushd "${dir_name}" || { echo "Error: Could not enter directory ${dir_name}. Skipping this NSB level."; continue; }
+
+    # Replace placeholders in the lstmcpipe command
+    # Replace X.XX with the current nsb_level for the output prod_id
+    # Replace PROD_ID with the source prod_id
+    executed_command=$(echo "${LSTMCPIPE_COMMAND_BASE}" | sed "s/X.XX/${nsb_level}/g" | sed "s/PROD_ID/${current_prod_id}/g")
+
+    echo "Running command: ${executed_command}"
+
+    # Execute the lstmcpipe command
+    eval "${executed_command}"
+
+    # Check if the command ran successfully
+    if [ $? -ne 0 ]; then
+        echo "Warning: lstmcpipe command failed for prod_id ${current_prod_id}."
+    fi
+
+    # Go back to the original directory
+    popd
+
+    echo "----------------------------------------"
+done
+
+echo "Script finished."


### PR DESCRIPTION
# PROD 20250701_v0.11.0_allsky_nsb_grid_retrain_models

This production is needed to retrain the models with lstchain v0.11.0 due to an incompatibility with the latest scikit-learn version.
See issue https://github.com/cta-observatory/cta-lstchain/issues/1366


Here we only do the training and testing again.
Configs generated with `make.sh`

author: Thomas V.

