### PR TITLE
Detect AllSky productions from the class, not from the class name

### DIFF
--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -107,12 +107,10 @@ Known pitfalls with the arguments
   ``--kwargs run_checker=False`` passes the *string* ``"False"``, which is truthy, and the checker still runs.
   To disable a checker, use the `Python API`_.
 
-* **The flavour of the generated lstchain config is decided from the class name.** If ``AllSky`` appears in the
-  class name, the standard AllSky lstchain MC config is dumped; otherwise the pointing-dependent RF features
-  (``alt_tel``, ``az_tel``, ``sin_az_tel``) are removed from it. Note that
-  ``PathConfigAllTrainTestDL1b`` does **not** contain ``AllSky`` in its name and therefore gets the
-  non-AllSky config: for an AllSky production, take the lstchain config of the source production, or dump one
-  with ``lstchain_dump_config --mc``.
+* **The flavour of the generated lstchain config depends on the config class.** For an AllSky production, the
+  standard lstchain MC config is dumped as is (the same one you would get from ``lstchain_dump_config --mc``).
+  For the prod3/prod5 pipelines, which have a fixed pointing, the pointing dependent RF features
+  (``alt_tel``, ``sin_az_tel``) are removed from it.
 
 * **--prod_id has a default.** Forgetting it silently produces a production called ``prod_00``.
 
@@ -681,12 +679,8 @@ At generation time, the merged training DL1 files of the source production are c
 A declination whose files are missing is **silently dropped** (with a warning) from the production: check the
 generated config contains all the declinations you asked for.
 
-.. warning::
-
-    The class name does not contain ``AllSky``, so the automatically dumped lstchain config is the
-    *non-AllSky* one, i.e. the pointing dependent RF features (``alt_tel``, ``az_tel``, ``sin_az_tel``) have
-    been removed. For an AllSky production, reuse the lstchain config of the source production instead, or
-    dump one with ``lstchain_dump_config --mc``.
+Since this production retrains models, consider reusing the lstchain config of the source production, so that
+only the training options you meant to change actually differ.
 
 
 .. _allsky-split-diffuse:

--- a/lstmcpipe/scripts/lstmcpipe_generate_config.py
+++ b/lstmcpipe/scripts/lstmcpipe_generate_config.py
@@ -38,6 +38,28 @@ def list_config_classes():
     return all_attrs
 
 
+def is_allsky_config(config_class):
+    """
+    Tell if a `lstmcpipe.config.paths_config.PathConfig` class describes an AllSky production.
+
+    The pointing dependent RF features (`alt_tel`, `sin_az_tel`) are only meaningful for AllSky productions,
+    so this drives the lstchain config that is dumped along with the lstmcpipe one.
+    It is based on the class inheritance and not on the class name, because not all the AllSky classes have
+    `AllSky` in their name (see `PathConfigAllTrainTestDL1b`).
+
+    Parameters
+    ----------
+    config_class: class
+        a class inheriting from `lstmcpipe.config.paths_config.PathConfig`
+
+    Returns
+    -------
+    bool
+    """
+    # PathConfigAllSkyFull inherits from PathConfig and not from PathConfigAllSkyBase, hence the two roots
+    return issubclass(config_class, (paths_config.PathConfigAllSkyBase, paths_config.PathConfigAllSkyFull))
+
+
 def build_argparser():
     parser = argparse.ArgumentParser(description="Generate a lstmcpipe config.")
 
@@ -99,6 +121,8 @@ def main():
     if not hasattr(paths_config, args.config_class):
         raise NotImplementedError(f"Config class {args.config_class} not implemented in lstmcpipe.config.paths_config")
 
+    config_class = getattr(paths_config, args.config_class)
+
     output = f"lstmcpipe_config_{date.today()}_{args.config_class}.yaml" if args.output is None else args.output
     prod_id = "prod_00" if args.prod_id is None else args.prod_id
 
@@ -110,8 +134,8 @@ def main():
     if args.kwargs:
         kwargs.update(args.kwargs)
 
-    # we get the class from its name and instantiate it with the required args
-    cfg = getattr(paths_config, args.config_class)(prod_id, **kwargs)
+    # we instantiate the class with the required args
+    cfg = config_class(prod_id, **kwargs)
     cfg.generate()
     cfg.save_yml(output, overwrite=args.overwrite)
 
@@ -119,10 +143,7 @@ def main():
 
     lstchain_file = f"lstchain_config_{date.today()}.json" if args.lstchain_conf is None else args.lstchain_conf
 
-    if "AllSky" in args.config_class:
-        allsky = True
-    else:
-        allsky = False
+    allsky = is_allsky_config(config_class)
     dump_lstchain_std_config(filename=lstchain_file, allsky=allsky, overwrite=args.overwrite)
     print(f"To start the process with dumped configs, run:\n\nlstmcpipe -c {output} -conf_lst {lstchain_file}\n\n")
 

--- a/lstmcpipe/scripts/tests/test_scripts.py
+++ b/lstmcpipe/scripts/tests/test_scripts.py
@@ -32,3 +32,21 @@ def run_script(*args):
 def test_all_help(script):
     """Test for all scripts if at least the help works."""
     run_script(script, "--help")
+
+
+def test_is_allsky_config():
+    """The AllSky productions must be recognised from the class inheritance, not from the class name"""
+    from lstmcpipe.config import paths_config
+    from lstmcpipe.scripts.lstmcpipe_generate_config import is_allsky_config, list_config_classes
+
+    assert not is_allsky_config(paths_config.PathConfigProd5Trans80)
+    assert not is_allsky_config(paths_config.PathConfigProd5Trans80DL1ab)
+    assert is_allsky_config(paths_config.PathConfigAllSkyFull)
+    assert is_allsky_config(paths_config.PathConfigAllSkyFullDL1ab)
+    # this one is an AllSky production although it has no `AllSky` in its name
+    assert is_allsky_config(paths_config.PathConfigAllTrainTestDL1b)
+
+    # a class named AllSky must always be detected as one
+    for class_name in list_config_classes():
+        if "AllSky" in class_name:
+            assert is_allsky_config(getattr(paths_config, class_name))

--- a/lstmcpipe/utils.py
+++ b/lstmcpipe/utils.py
@@ -180,7 +180,6 @@ def dump_lstchain_std_config(filename='lstchain_config.json', allsky=True, overw
             'disp_classification_features',
             'particle_classification_features',
         ]:
-            cfg[rf_feature] = std_cfg[rf_feature]
             for feature in ['alt_tel', 'az_tel', 'sin_az_tel']:
                 if feature in cfg[rf_feature]:
                     cfg[rf_feature].remove(feature)


### PR DESCRIPTION
Follow-up to #540: fixes the bug that PR documented as expected behaviour in a `.. warning::` block, and removes that warning.

## The bug

`lstmcpipe_generate_config` chose which lstchain config to dump with a substring test on the class name:

```python
if "AllSky" in args.config_class:
    allsky = True
```

`PathConfigAllTrainTestDL1b` is an AllSky production whose name does not spell out `AllSky`, so it got the config meant for fixed-pointing productions, with `alt_tel` and `sin_az_tel` stripped from all four RF feature lists. Since that class exists precisely to retrain models, the generated config trained AllSky models without their pointing dependence.

It is the only class where the name and the type disagree, but the check is fragile by construction, so it is now based on the class inheritance:

```python
return issubclass(config_class, (paths_config.PathConfigAllSkyBase, paths_config.PathConfigAllSkyFull))
```

Two roots are needed because `PathConfigAllSkyFull` inherits from `PathConfig`, not from `PathConfigAllSkyBase`.

| Class | old name check | new type check |
|---|---|---|
| `PathConfigProd5Trans80`, `PathConfigProd5Trans80DL1ab` | False | False |
| the 10 `PathConfigAllSky*` classes | True | True |
| **`PathConfigAllTrainTestDL1b`** | **False** | **True** |

## No post-processing is needed for AllSky

Checked against lstchain v0.12.3: `get_mc_config()` — the same function behind `lstchain_dump_config --mc` — is `lstchain_standard_config.json` updated with `lstchain_mc_config.json`, and the latter only overrides `GlobalPeakWindowSum` / `LocalPeakWindowSum`. The standard config already carries `sin_az_tel` and `alt_tel` in all four feature lists, so what lstchain gives us is already the AllSky config. Only the prod3/prod5 pipelines need the pointing features removed.

(`az_tel`, still in lstmcpipe's removal list, no longer exists in lstchain's config. It is a guarded no-op, kept for compatibility with older lstchain.)

## Bonus fix in `dump_lstchain_std_config`

```python
cfg[rf_feature] = std_cfg[rf_feature]   # cfg's key now aliases std_cfg's *same list*
... cfg[rf_feature].remove(feature)     # so this mutated std_cfg too
diff = DeepDiff(std_cfg, cfg)           # -> always {}
```

`cfg` is already a `deepcopy`, so that line only re-aliased the lists, and the diff printed right after was always empty for the non-AllSky case. The dumped file was correct; only the report lied. Removing the line makes it report the 8 removed features.

## Verification

End-to-end with lstchain 0.12.3 installed, dumping the config each class would actually produce:

```
PathConfigAllTrainTestDL1b   allsky=True   pointing features kept: ['sin_az_tel', 'alt_tel']   <- was []
PathConfigAllSkyFull         allsky=True   pointing features kept: ['sin_az_tel', 'alt_tel']
PathConfigProd5Trans80       allsky=False  pointing features kept: []
```

`test_is_allsky_config` added to `lstmcpipe/scripts/tests/test_scripts.py`; it needs no lstchain import. The pre-existing `test_all_help` failures in that file are unrelated (`ctaplot` imports `distutils`, removed in Python 3.14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkVpceYdeASDZXbsqVMSsY
